### PR TITLE
Add casetype option. Default to what is defined in config

### DIFF
--- a/src/xsoar_cli/case/commands.py
+++ b/src/xsoar_cli/case/commands.py
@@ -63,17 +63,20 @@ def clone(ctx: click.Context, casenumber: int, source: str, dest: str) -> None:
 
 
 @click.option("--environment", default="dev", show_default=True, help="Environment as defined in config file")
+@click.option("--casetype", default="", show_default=True, help="Create case of specified type. Default type set in config file.")
 @click.argument("details", type=str, default="Placeholder case details")
 @click.argument("name", type=str, default="Test case created from xsoar-cli")
-@click.command(help="Creates a single new case in XSOAR")
 @click.pass_context
 @load_config
-def create(ctx: click.Context, environment: str, name: str, details: str) -> None:
+def create(ctx: click.Context, environment: str, casetype: str, name: str, details: str) -> None:
+    """Creates a new case in XSOAR. If invalid case type is specified as a command option, XSOAR will default to using Unclassified."""
     xsoar_client: Client = ctx.obj["server_envs"][environment]
+    if not casetype:
+        casetype = ctx.obj["default_new_case_type"]
     data = {
         "createInvestigation": True,
         "name": name,
-        "type": "MyCaseType",  # grab this from config maybe?
+        "type": casetype,
         "details": details,
     }
     case_data = xsoar_client.create_case(data=data)

--- a/src/xsoar_cli/utilities.py
+++ b/src/xsoar_cli/utilities.py
@@ -80,6 +80,7 @@ def parse_config(config: dict, ctx: click.Context) -> None:
     ctx.obj = {}
     ctx.obj["default_environment"] = config["default_environment"]
     ctx.obj["custom_pack_authors"] = config["custom_pack_authors"]
+    ctx.obj["default_new_case_type"] = config["default_new_case_type"]
     ctx.obj["server_envs"] = {}
     for key in config["server_config"]:
         ctx.obj["server_envs"][key] = Client(


### PR DESCRIPTION
When doing `xsoar-cli case create` the case created should be of the same type as the one defined in config.
If an invalid case type is entered then XSOAR will default to Unclassified.