### PR TITLE
Allow manifest validation to check diff from installed versions

### DIFF
--- a/src/xsoar_cli/manifest/commands.py
+++ b/src/xsoar_cli/manifest/commands.py
@@ -111,45 +111,81 @@ def update(ctx: click.Context, environment: str | None, manifest: str) -> None:
 
 
 @click.option("--environment", default=None, help="Default environment set in config file.")
+@click.option("--mode", type=click.Choice(["full", "diff"]), default="diff", help="Validate the full manifest, or only the definitions that diff with installed versions")
 @click.argument("manifest", type=str)
 @click.command()
 @click.pass_context
 @load_config
-def validate(ctx: click.Context, environment: str | None, manifest: str) -> None:
-    """Validate manifest JSON and all pack availability. Validates upstream pack availability by doing HTTP CONNECT.
+def validate(ctx: click.Context, environment: str | None, mode: str, manifest: str) -> None:
+    """Validate manifest JSON and content pack availability by doing HTTP CONNECT to the appropriate artifacts repository.
     Custom pack availability is implementation dependant."""
     if not environment:
         environment = ctx.obj["default_environment"]
     xsoar_client: Client = ctx.obj["server_envs"][environment]["xsoar_client"]
+
     manifest_data = load_manifest(manifest)
     click.echo("Manifest is valid JSON")
     keys = ["custom_packs", "marketplace_packs"]
-    for key in keys:
-        custom = key == "custom_packs"
-        click.echo(f"Checking {key} availability ", nl=False)
-        for pack in manifest_data[key]:
-            if not xsoar_client.is_pack_available(pack_id=pack["id"], version=pack["version"], custom=custom):
-                # If we are in a merge request and the merge request contains a new pack as well
-                # as a updated xsoar_config.json manifest, then the pack is not available in S3
-                # before the MR is merged. Check if we can find the appropriate pack version locally
-                # If so, we can ignore this error because the pack will become available after merge.
-                manifest_arg = Path(manifest)
-                manifest_path = manifest_arg.resolve()
-                repo_path = manifest_path.parent
-                pack_metadata_path = Path(f"{repo_path}/Packs/{pack['id']}/pack_metadata.json")
-                with Path.open(pack_metadata_path, encoding="utf-8") as f:
-                    pack_metadata = json.load(f)
 
-                if pack_metadata["currentVersion"] == pack["version"]:
-                    continue
-                # The object key does not exist in AWS S3, and the relevant Pack locally does not have
-                # the requested version.
-                click.echo(f"\nFailed to reach pack {pack['id']} version {pack['version']}")
-                sys.exit(1)
-            click.echo(".", nl=False)
-        print()
 
-    click.echo("Manifest is valid JSON and all packs are reachable.")
+    def found_in_local_filesystem() -> bool:
+        # If we are in a merge request and the merge request contains a new pack as well
+        # as a updated xsoar_config.json manifest, then the pack is not available in S3
+        # before the MR is merged. Check if we can find the appropriate pack version locally
+        # If so, we can ignore this error because the pack will become available after merge.
+        manifest_arg = Path(manifest)
+        manifest_path = manifest_arg.resolve()
+        repo_path = manifest_path.parent
+        pack_metadata_path = Path(f"{repo_path}/Packs/{pack['id']}/pack_metadata.json")
+        with Path.open(pack_metadata_path, encoding="utf-8") as f:
+            pack_metadata = json.load(f)
+        if pack_metadata["currentVersion"] == pack["version"]:
+            return True
+        # The relevant Pack locally does not have the requested version.
+        return False
+
+    if mode == "full":
+        for key in keys:
+            custom = key == "custom_packs"
+            click.echo(f"Checking {key} availability ", nl=False)
+            for pack in manifest_data[key]:
+                available = xsoar_client.is_pack_available(pack_id=pack["id"], version=pack["version"], custom=custom)
+                # We check if a pack is found in local filesystem regardless of whether it's an upstream pack or not.
+                # This should cause any significantly negative performance penalties.
+                if not available and not found_in_local_filesystem():
+                    click.echo(f"\nFailed to reach pack {pack['id']} version {pack['version']}")
+                    sys.exit(1)
+                click.echo(".", nl=False)
+            print()
+        click.echo("Manifest is valid JSON and all packs are reachable")
+        return
+    elif mode == "diff":
+        installed_packs = xsoar_client.get_installed_packs()
+        for key in keys:
+            found_diff = False
+            custom = key == "custom_packs"
+            click.echo(f"Checking {key} availability ", nl=False)
+            for pack in manifest_data[key]:
+                installed = next((item for item in installed_packs if item["id"] == pack["id"]), {})
+                if not installed or installed["currentVersion"] != pack["version"]:
+                    available = xsoar_client.is_pack_available(pack_id=pack["id"], version=pack["version"], custom=custom)
+                    # We check if a pack is found in local filesystem regardless of whether it's an upstream pack or not.
+                    # This should cause any significantly negative performance penalties.
+                    if not available and not found_in_local_filesystem():
+                        click.echo(f"\nFailed to reach pack {pack['id']} version {pack['version']}")
+                        sys.exit(1)
+                    click.echo(".", nl=False)
+                    found_diff = True
+            if not found_diff:
+                click.echo("- no diff from installed versions found in manifest.")
+            else:
+                print()
+
+        click.echo("Manifest is valid JSON and all packs are reachable.")
+        return
+    else:
+        msg = "Invalid value for --mode detected. This should never happen"
+        raise RuntimeError(msg)
 
 
 @click.option("--environment", default=None, help="Default environment set in config file.")


### PR DESCRIPTION
Add a new --mode option to `xsoar-cli manifest validate` with accepted values _full_ or _diff_. Default value is __diff__.
Using `--mode full` will validate every content pack in the manifest, while using `--mode diff` will only validate the manifest definitions that differ from the list of installed content pack retrieved from the XSOAR server.