### PR TITLE
Fix playbook download

### DIFF
--- a/src/xsoar_cli/playbook/commands.py
+++ b/src/xsoar_cli/playbook/commands.py
@@ -76,7 +76,7 @@ def download(ctx: click.Context, environment: str | None, name: str) -> None:
             "--no-validate",
             "--no-graph",
             "--from-version",
-            "6.1.2",
+            "6.10.0",
             str(filepath),
         ],
         check=False,


### PR DESCRIPTION
In recent versions of demisto-sdk users will be prompted to format playbooks as a "silent playbook". Using assume-yes is problematic here because it will automagically set fromversion to 8.9.0. Using "--assume-no" and explicitly setting "--from-version" allows for non-interactive formatting.