### PR TITLE
Add lazy import pattern for heavy dependencies throughout codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,10 @@ uv run xsoar-cli --help
 - The `@load_config` decorator (in `utilities.py`) handles config loading and injects `XSOARConfig` into `ctx.obj`
 - Use `click.echo()` for user-facing output, `logging` for debug/file logs
 - Commands that iterate over both `custom_packs` and `marketplace_packs` must use a `pack_type` variable (`"Custom"` / `"Marketplace"`) and include it in all log messages so the pack origin is always explicit in debug output
-- Logging setup in `cli.py` is intentionally deferred to `main()`. Command and plugin registration happen at module level, but `_configure_logging()` must not be moved there -- see inline comments in `cli.py` for details
+- Logging setup in `cli.py` is intentionally deferred to `main()`. Command and plugin registration happen at module level, but `_configure_logging()` must not be moved there. See inline comments in `cli.py` for details
 - Ruff noqa comments are used where rules are intentionally suppressed (e.g., `# noqa: PLR0913` for many parameters, `# noqa: ANN201` for fixture return types)
 - Type hints are used throughout; `str | None` union syntax (Python 3.10+)
+- Heavy third-party imports (`xsoar_client`, `xsoar_dependency_graph`, `demisto_client`, etc.) must be deferred into the function or method bodies that use them, not imported at module level. This avoids loading slow transitive dependencies (boto3, azure-storage-blob, matplotlib, networkx, etc.) at CLI startup, keeping `--help` and `--version` fast. Use `from __future__ import annotations` together with a `TYPE_CHECKING` block so type hints remain clean and unquoted. Mark each deferred import with the comment `# Lazy import for performance reasons`. When patching deferred imports in tests, patch at the source (`xsoar_client.xsoar_client.Client`) rather than the importing module (`xsoar_cli.configuration.Client`)
 - Tests must not produce side effects on the real filesystem, such as writing to the log file. Tests invoke `cli()` directly via Click's `CliRunner`, bypassing `main()` and its logging setup
 - Tests use `unittest.mock.patch` to mock external dependencies (`xsoar_client`, config file I/O)
 - Test classes follow `class TestX` naming; test methods use `test_` prefix
@@ -107,11 +108,11 @@ uv run xsoar-cli --help
 
 ## Workflow
 
-- Prefer plain, natural language in comments and documentation. Avoid formal or academic wording where a simpler alternative exists
+- Write comments and documentation in plain, natural language. Avoid formal or academic wording where a simpler alternative exists. Do not use em dashes ("--" or "—") as parenthetical separators; use periods, commas, or parentheses instead. Avoid filler phrases like "It is worth noting that" or "It should be noted that". Keep sentences short and direct.
 - Never start with code. Always plan changes properly before implementation. Ask for clarification in case of inconsistencies or missing information. Do not make assumptions. Confirm with user before generating code.
 - In case of larger modifications, do implementation in logically grouped steps. Complex modifications may be broken down further.
 - After completing each step, stop and wait for the user to review and confirm before proceeding to the next step.
-- Each step should be small enough to be comfortably reviewed -- as a rule of thumb, no more than one or two files modified per step.
+- Each step should be small enough to be comfortably reviewed. As a rule of thumb, no more than one or two files modified per step.
 
 ## Plugin System
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,22 @@ pip install -e /path/to/your/xsoar-dependency-graph
 - Add type hints where appropriate
 - Write docstrings for new functions and classes
 
+#### Lazy imports
+
+Heavy third-party packages like `xsoar_client`, `xsoar_dependency_graph` and `demisto_client` pull in large dependency trees (boto3, azure-storage-blob, matplotlib, networkx, etc.) that are expensive to load. To keep everyday invocations like `--help` and `--version` fast, these imports are placed inside the functions that need them rather than at the top of the file. Each lazy import is marked with the comment `# Lazy import for performance reasons`.
+
+Type hints for the deferred types still appear in function signatures. To avoid quoting them as strings, modules that use this pattern include `from __future__ import annotations` and a `TYPE_CHECKING` block at the top:
+
+```python
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from xsoar_client.xsoar_client import Client
+```
+
+See `configuration.py` for a complete example.
+
 ### Testing
 - Add tests for new features
 - Ensure existing tests still pass

--- a/src/xsoar_cli/configuration.py
+++ b/src/xsoar_cli/configuration.py
@@ -1,12 +1,14 @@
 """Configuration management for XSOAR CLI."""
 
-import logging
-from typing import Optional
+from __future__ import annotations
 
-from xsoar_client.artifact_providers.azure import AzureArtifactProvider
-from xsoar_client.artifact_providers.s3 import S3ArtifactProvider
-from xsoar_client.config import ClientConfig
-from xsoar_client.xsoar_client import Client
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from xsoar_client.artifact_providers.azure import AzureArtifactProvider
+    from xsoar_client.artifact_providers.s3 import S3ArtifactProvider
+    from xsoar_client.xsoar_client import Client
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +20,7 @@ class EnvironmentConfig:
         self.env_name = env_name
         self._config = config
         self.custom_pack_authors = custom_pack_authors
-        self._client: Optional[Client] = None
+        self._client: Client | None = None
 
     @property
     def client(self) -> Client:
@@ -30,6 +32,10 @@ class EnvironmentConfig:
 
     def _create_client(self) -> Client:
         """Create the XSOAR client with artifact provider."""
+        # Lazy import for performance reasons
+        from xsoar_client.config import ClientConfig
+        from xsoar_client.xsoar_client import Client
+
         logger.debug(
             "Client config for '%s': server_version=%s, base_url=%s, verify_ssl=%s",
             self.env_name,
@@ -55,10 +61,16 @@ class EnvironmentConfig:
         artifacts_location = self._config.get("artifacts_location")
 
         if artifacts_location == "S3":
+            # Lazy import for performance reasons
+            from xsoar_client.artifact_providers.s3 import S3ArtifactProvider
+
             bucket_name = self._config.get("s3_bucket_name", "")
             logger.debug("Creating S3 artifact provider for '%s' (bucket: %s)", self.env_name, bucket_name)
             return S3ArtifactProvider(bucket_name=bucket_name)
         elif artifacts_location == "Azure":
+            # Lazy import for performance reasons
+            from xsoar_client.artifact_providers.azure import AzureArtifactProvider
+
             logger.debug("Creating Azure artifact provider for '%s'", self.env_name)
             return AzureArtifactProvider(
                 storage_account_url=self._config["azure_blobstore_url"],
@@ -92,7 +104,7 @@ class XSOARConfig:
             list(self._environments.keys()),
         )
 
-    def get_client(self, environment: Optional[str] = None) -> Client:
+    def get_client(self, environment: str | None = None) -> Client:
         """Get the XSOAR client for the specified environment (or default)."""
         env = environment or self.default_environment
         if env not in self._environments:
@@ -110,7 +122,7 @@ class XSOARConfig:
         """Get list of all configured environment names."""
         return list(self._environments.keys())
 
-    def environment_has_artifacts(self, environment: Optional[str] = None) -> bool:
+    def environment_has_artifacts(self, environment: str | None = None) -> bool:
         """Check if an environment has artifact provider configured."""
         env = environment or self.default_environment
         return self._environments[env].has_artifact_provider

--- a/src/xsoar_cli/connection_errors.py
+++ b/src/xsoar_cli/connection_errors.py
@@ -1,4 +1,9 @@
-from urllib3.exceptions import NameResolutionError
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from urllib3.exceptions import NameResolutionError
 
 
 class ConnectionErrorHandler:
@@ -8,6 +13,9 @@ class ConnectionErrorHandler:
         """Return a user-friendly error message from an exception chain."""
         if exception is None:
             return "Unknown error"
+
+        # Lazy import for performance reasons
+        from urllib3.exceptions import NameResolutionError
 
         # Walk through the exception chain to find known error types and the root cause
         current = exception

--- a/src/xsoar_cli/graph/commands.py
+++ b/src/xsoar_cli/graph/commands.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
-from xsoar_client.xsoar_client import Client
-from xsoar_dependency_graph.xsoar_dependency_graph import ContentGraph
 
 from xsoar_cli.utilities import (
     get_xsoar_config,
     load_config,
     validate_xsoar_connectivity,
 )
+
+if TYPE_CHECKING:
+    from xsoar_client.xsoar_client import Client
+    from xsoar_dependency_graph.xsoar_dependency_graph import ContentGraph
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +42,9 @@ def _build_content_graph(
     environment: str | None,
 ) -> ContentGraph:
     """Shared setup: load config, connect to XSOAR, build and return a ContentGraph."""
+    # Lazy import for performance reasons
+    from xsoar_dependency_graph.xsoar_dependency_graph import ContentGraph
+
     config = get_xsoar_config(ctx)
     xsoar_client: Client = config.get_client(environment)
     logger.info("Generating dependency graph (environment: '%s', repo: '%s')", environment or config.default_environment, repo_path)

--- a/src/xsoar_cli/manifest/commands.py
+++ b/src/xsoar_cli/manifest/commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import sys
@@ -5,8 +7,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
-from demisto_client.demisto_api.rest import ApiException
-from packaging.version import Version
 
 from xsoar_cli.utilities import (
     find_installed_packs_not_in_manifest,
@@ -91,6 +91,9 @@ def generate(ctx: click.Context, environment: str | None, manifest_path: str) ->
 @validate_xsoar_connectivity()
 def update(ctx: click.Context, environment: str | None, manifest: str) -> None:
     """Update manifest on disk with latest available content pack versions."""
+    # Lazy import for performance reasons
+    from packaging.version import Version
+
     config = get_xsoar_config(ctx)
     xsoar_client: Client = config.get_client(environment)
     logger.info("Updating manifest '%s' (environment: '%s')", manifest, environment or config.default_environment)
@@ -362,6 +365,9 @@ def deploy(ctx: click.Context, environment: str | None, manifest: str, verbose: 
     \b
     Prompts for confirmation prior to pack installation.
     """
+    # Lazy import for performance reasons
+    from demisto_client.demisto_api.rest import ApiException
+
     # Initialize client and determine target environment
     config = get_xsoar_config(ctx)
     xsoar_client: Client = config.get_client(environment)

--- a/src/xsoar_cli/rbac/commands.py
+++ b/src/xsoar_cli/rbac/commands.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import click
 
-import xsoar_cli
 from xsoar_cli.utilities import get_xsoar_config, load_config, validate_xsoar_connectivity
 
 if TYPE_CHECKING:
@@ -46,9 +45,6 @@ def getusers(ctx: click.Context, environment: str | None) -> None:
     users = json.loads(results)
     click.echo(json.dumps(users, sort_keys=True, indent=4) + "\n")
 
-    config = get_xsoar_config(ctx)
-    xsoar_client: Client = config.get_client(environment)
-
 
 @click.option("--environment", default=None, help="Default environment set in config file.")
 @click.command()
@@ -56,11 +52,11 @@ def getusers(ctx: click.Context, environment: str | None) -> None:
 @load_config
 @validate_xsoar_connectivity()
 def getusergroups(ctx: click.Context, environment: str | None) -> None:
-    """Dump all roles in your environment."""
+    """Dump all user groups in your environment. XSOAR 8+ only."""
     config = get_xsoar_config(ctx)
     xsoar_client: Client = config.get_client(environment)
     if xsoar_client.config.server_version < 8:
-        click.echo("Errot: Command not supported for XSOAR server versions less than 8")
+        click.echo("Error: Command not supported for XSOAR server versions less than 8")
         ctx.exit(1)
     results = xsoar_client.get_user_groups()
     user_groups = json.loads(results)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from xsoar_cli import cli
 
 
 class TestConfig:
-    @patch("xsoar_cli.configuration.Client")
+    @patch("xsoar_client.xsoar_client.Client")
     @patch("pathlib.Path.is_file", MagicMock(return_value=True))
     @pytest.mark.parametrize(
         ("cli_args", "use_fixtures", "expected_return_value"),


### PR DESCRIPTION
Deferred imports for xsoar_client, xsoar_dependency_graph, demisto_client, and packaging.version are now placed inside functions for performance. Added TYPE_CHECKING blocks and updated type hints to use Python 3.10+ union syntax. Updated documentation to clarify lazy import conventions. Fixed minor typos and improved workflow section wording in CLAUDE.md.