### PR TITLE
Add config set-version-check command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `config set-version-check` command to enable or disable the version update check on CLI startup. Accepts `--enable` or `--disable`.
+
 ## [2.1.1] - 2026-04-08
 
 ### Changed

--- a/src/xsoar_cli/commands/config/README.md
+++ b/src/xsoar_cli/commands/config/README.md
@@ -101,3 +101,21 @@ Set the Azure Blob Storage SAS token for an environment in the configuration fil
 xsoar-cli config set-azure-token my-sas-token
 xsoar-cli config set-azure-token --environment prod my-sas-token
 ```
+
+## Set Version Check
+
+Enable or disable the version update check on CLI startup. When enabled, the CLI checks PyPI for newer versions and prints a notice to stderr.
+
+**Syntax:** `xsoar-cli config set-version-check [OPTIONS]`
+
+**Options:**
+- `--enable` - Enable the version update check
+- `--disable` - Disable the version update check
+
+One of `--enable` or `--disable` must be provided.
+
+**Examples:**
+```
+xsoar-cli config set-version-check --enable
+xsoar-cli config set-version-check --disable
+```

--- a/src/xsoar_cli/commands/config/commands.py
+++ b/src/xsoar_cli/commands/config/commands.py
@@ -203,8 +203,28 @@ def set_azure_token(ctx: click.Context, environment: str, sastoken: str) -> None
     logger.info("Azure SAS token updated for environment '%s'", environment)
 
 
+@click.command()
+@click.option("--enable", "action", flag_value="enable", help="Enable the version update check on CLI startup.")
+@click.option("--disable", "action", flag_value="disable", help="Disable the version update check on CLI startup.")
+@click.pass_context
+@load_config
+def set_version_check(ctx: click.Context, action: str | None) -> None:  # noqa: ARG001
+    """Enable or disable the version update check on CLI startup."""
+    if action is None:
+        raise click.UsageError("Specify either --enable or --disable.")
+    config_file = get_config_file_path()
+    config_data = json.loads(config_file.read_text())
+    # skip_version_check is the inverse: enabling the check means skip=False.
+    config_data["skip_version_check"] = action == "disable"
+    config_file.write_text(json.dumps(config_data, indent=4))
+    state = "enabled" if action == "enable" else "disabled"
+    logger.info("Version check %s", state)
+    click.echo(f"Version check {state}.")
+
+
 config.add_command(create)
 config.add_command(validate)
 config.add_command(show)
 config.add_command(set_credentials)
 config.add_command(set_azure_token)
+config.add_command(set_version_check)

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from xsoar_cli.commands.config.commands import get_config_file_template_contents
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from tests.cli.conftest import InvokeHelper
 
 
@@ -137,6 +143,39 @@ class TestConfigValidateMutualExclusivity:
         result = invoke(["config", "validate", "--all", "--only-test-environment", "prod"])
         assert result.exit_code != 0
         assert "mutually exclusive" in result.output
+
+
+class TestConfigSetVersionCheck:
+    """Tests for config set-version-check."""
+
+    def test_enable_sets_skip_to_false(self, invoke: InvokeHelper, mock_config_file, tmp_path: Path) -> None:
+        config_data = get_config_file_template_contents()
+        config_data["skip_version_check"] = True
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config_data, indent=4))
+        with patch("xsoar_cli.commands.config.commands.get_config_file_path", return_value=config_file):
+            result = invoke(["config", "set-version-check", "--enable"])
+        assert result.exit_code == 0
+        assert "Version check enabled." in result.output
+        updated = json.loads(config_file.read_text())
+        assert updated["skip_version_check"] is False
+
+    def test_disable_sets_skip_to_true(self, invoke: InvokeHelper, mock_config_file, tmp_path: Path) -> None:
+        config_data = get_config_file_template_contents()
+        config_data["skip_version_check"] = False
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config_data, indent=4))
+        with patch("xsoar_cli.commands.config.commands.get_config_file_path", return_value=config_file):
+            result = invoke(["config", "set-version-check", "--disable"])
+        assert result.exit_code == 0
+        assert "Version check disabled." in result.output
+        updated = json.loads(config_file.read_text())
+        assert updated["skip_version_check"] is True
+
+    def test_no_flag_shows_usage_error(self, invoke: InvokeHelper, mock_config_file) -> None:
+        result = invoke(["config", "set-version-check"])
+        assert result.exit_code != 0
+        assert "--enable" in result.output or "--disable" in result.output
 
 
 class TestConfigValidateVerbose:


### PR DESCRIPTION
Add a new `config set-version-check` subcommand to enable or disable the version update check on CLI startup.

## Changes

- **`src/xsoar_cli/commands/config/commands.py`** -- New `set_version_check` command with mutually exclusive `--enable`/`--disable` flags. Maps to the `skip_version_check` config key (inverted: `--enable` sets `skip_version_check` to `false`).
- **`tests/cli/test_config.py`** -- Three test cases: enable, disable, and missing flag.
- **`src/xsoar_cli/commands/config/README.md`** -- Documented the new subcommand.
- **`CHANGELOG.md`** -- Added entry under `[Unreleased]`.