### PR TITLE
Update changelog and fix stale default in get-detached command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `config set-version-check` command to enable or disable the version update check on CLI startup. Accepts `--enable` or `--disable`.
 
+### Changed
+
+- `content get-detached --type` is now required. The `all` choice has been removed; specify `scripts` or `playbooks` explicitly.
+- `integration dump`, `rbac getroles`, `rbac getusers`, and `rbac getusergroups` no longer emit a trailing blank line after JSON output.
+- `config show` now uses `click.echo()` instead of `print()`, improving behavior when piping output to other tools.
+
+### Fixed
+
+- `content get-detached` no longer fails when invoked without `--type` due to a stale default value that referenced the removed `all` choice.
+- Content bundle download (`get_content_bundle`) now raises on HTTP errors instead of silently proceeding and failing with a confusing `tarfile` error.
+
 ## [2.1.1] - 2026-04-08
 
 ### Changed

--- a/src/xsoar_cli/commands/content/commands.py
+++ b/src/xsoar_cli/commands/content/commands.py
@@ -29,8 +29,7 @@ def content() -> None:
     "--type",
     "content_type",
     type=click.Choice(["scripts", "playbooks"], case_sensitive=False),
-    default="all",
-    show_default=True,
+    required=True,
     help="Type of content items to retrieve.",
 )
 @click.pass_context


### PR DESCRIPTION
## Changes

### Bug fix
- `content get-detached --type` had a stale `default="all"` after the `all` choice was removed from `click.Choice`. Running the command without `--type` would fail with a Click validation error. The option is now required.

### Changelog
Added missing entries under `[Unreleased]` for recent changes:
- **Changed**: `content get-detached --type` is now required.
- **Changed**: Trailing blank line removed from JSON output of `integration dump`, `rbac getroles`, `rbac getusers`, `rbac getusergroups`.
- **Changed**: `config show` now uses `click.echo()` instead of `print()`.
- **Fixed**: `content get-detached` stale default value.
- **Fixed**: `get_content_bundle` now raises on HTTP errors.