### PR TITLE
Refactor plugin system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - `config set-version-check` command to enable or disable the version update check on CLI startup. Accepts `--enable` or `--disable`.
+- `plugins init` command to create the plugins directory and generate an example plugin.
 
 ### Changed
 
+- Plugins must explicitly import `XSOARPlugin` (`from xsoar_cli.plugins import XSOARPlugin`). The base class is no longer injected automatically. See the [plugin README](src/xsoar_cli/plugins/README.md) for details.
+- Plugin commands (`list`, `info`, `validate`) now report a clear error when the plugins directory has not been initialized.
+- Plugin registration failures no longer prevent remaining plugins from loading.
 - `content get-detached --type` is now required. The `all` choice has been removed; specify `scripts` or `playbooks` explicitly.
 - `integration dump`, `rbac getroles`, `rbac getusers`, and `rbac getusergroups` no longer emit a trailing blank line after JSON output.
 - `config show` now uses `click.echo()` instead of `print()`, improving behavior when piping output to other tools.
+
+### Removed
+
+- Automatic creation of the plugins directory on CLI startup.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Plugins must explicitly import `XSOARPlugin` (`from xsoar_cli.plugins import XSOARPlugin`). The base class is no longer injected automatically. See the [plugin README](src/xsoar_cli/plugins/README.md) for details.
+- **Breaking:** Plugins must explicitly import `XSOARPlugin` (`from xsoar_cli.plugins import XSOARPlugin`). The base class is no longer injected automatically. See the [plugin README](src/xsoar_cli/plugins/README.md) for details.
 - Plugin commands (`list`, `info`, `validate`) now report a clear error when the plugins directory has not been initialized.
 - Plugin registration failures no longer prevent remaining plugins from loading.
 - `content get-detached --type` is now required. The `all` choice has been removed; specify `scripts` or `playbooks` explicitly.
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
-- Automatic creation of the plugins directory on CLI startup.
+- **Breaking:** Automatic creation of the plugins directory on CLI startup. Run `xsoar-cli plugins init` to create it explicitly.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **Breaking:** Plugins must explicitly import `XSOARPlugin` (`from xsoar_cli.plugins import XSOARPlugin`). The base class is no longer injected automatically. See the [plugin README](src/xsoar_cli/plugins/README.md) for details.
+- **Breaking:** Plugins must explicitly import `XSOARPlugin` (`from xsoar_cli.plugins import XSOARPlugin`). The base class is no longer injected automatically and so old plugins require modification. See the [plugin README](src/xsoar_cli/plugins/README.md) for details.
 - Plugin commands (`list`, `info`, `validate`) now report a clear error when the plugins directory has not been initialized.
 - Plugin registration failures no longer prevent remaining plugins from loading.
 - `content get-detached --type` is now required. The `all` choice has been removed; specify `scripts` or `playbooks` explicitly.
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
-- **Breaking:** Automatic creation of the plugins directory on CLI startup. Run `xsoar-cli plugins init` to create it explicitly.
+- The plugins directory is no longer automatically created on CLI startup. Run `xsoar-cli plugins init` to create it explicitly.
 
 ### Fixed
 

--- a/PLUGIN_REFACTOR.md
+++ b/PLUGIN_REFACTOR.md
@@ -1,0 +1,179 @@
+# Plugin System Refactor Plan
+
+This document describes the planned refactor of the xsoar-cli plugin system to align it with the project's code conventions and design patterns.
+
+## Breaking Changes
+
+Removing the magic `XSOARPlugin` injection from `_load_module_from_file` means existing plugins that rely on `XSOARPlugin` being available without an import will fail with a `NameError`. Plugin authors must add an explicit import:
+
+```python
+from xsoar_cli.plugins import XSOARPlugin
+```
+
+This is the only breaking change. All other plugin behavior (discovery, loading, registration, conflict detection) remains the same once the plugins directory exists.
+
+## Step 1: Fix `plugins/__init__.py`
+
+Align the base class module with project conventions.
+
+### Changes
+
+- Add `from __future__ import annotations`.
+- Replace `Optional[str]` with `str | None` and remove the `typing` import.
+- Trim the module docstring and method docstrings to match the terse, direct style used elsewhere.
+- Remove the Google-style `Returns:` block from `get_command`.
+
+### Files modified
+
+- `src/xsoar_cli/plugins/__init__.py`
+
+## Step 2: Refactor `plugins/manager.py`
+
+Remove side effects from the constructor and drop unnecessary magic.
+
+### Changes
+
+- Remove `self.plugins_dir.mkdir(parents=True, exist_ok=True)` from `__init__`. Directory creation moves to the new `plugins init` command (step 3).
+- Remove the `sys.path` manipulation entirely. `spec_from_file_location` loads modules by full path and does not need `sys.path`. Inter-plugin imports are not supported (documented in step 6).
+- Remove `XSOARPlugin` injection (`setattr(module, "XSOARPlugin", XSOARPlugin)`) from `_load_module_from_file`. Plugins must use an explicit import.
+- Add a directory-existence guard at the top of `discover_plugins`: if `self.plugins_dir` does not exist, log a debug message and return an empty list.
+- Add a `plugins_dir_exists` property that returns `bool`. Commands use this to emit "not initialized" errors.
+- Trim docstrings to match project style.
+
+### Implementation notes
+
+`load_all_plugins` already calls `discover_plugins`, which will return an empty list when the directory is missing. No additional guard is needed in `load_all_plugins` itself.
+
+The `import types` and `import sys` imports at the top of the file can be cleaned up: `types` is still needed for the return type of `_load_module_from_file`, but `sys` is only needed for `sys.modules` (used when registering loaded modules). The `sys.path` lines are the only ones being removed.
+
+### Files modified
+
+- `src/xsoar_cli/plugins/manager.py`
+
+## Step 3: Add `plugins init` command, refactor existing plugin commands
+
+Introduce explicit initialization and fix command-level conventions.
+
+### New command: `plugins init`
+
+Creates the plugins directory at `~/.local/xsoar-cli/plugins/` and drops a hello world example plugin into it. Behavior mirrors `config create`:
+
+- If the directory already exists, prompt for confirmation before overwriting the example plugin.
+- If the directory does not exist, create it (including parents).
+- Write a single `hello.py` file that demonstrates the plugin contract.
+
+Example plugin content:
+
+```python
+import click
+
+from xsoar_cli.plugins import XSOARPlugin
+
+
+class HelloPlugin(XSOARPlugin):
+    @property
+    def name(self) -> str:
+        return "hello"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    @property
+    def description(self) -> str:
+        return "Example plugin. Modify or replace this file."
+
+    def get_command(self) -> click.Command:
+        @click.command()
+        @click.option("--name", default="World", help="Name to greet")
+        def hello(name: str) -> None:
+            """Say hello."""
+            click.echo(f"Hello, {name}!")
+
+        return hello
+```
+
+### Refactor existing commands: `list`, `info`, `validate`
+
+- Stop creating new `PluginManager()` instances. Access the module-level `plugin_manager` from `cli.py` via a lazy import (`from xsoar_cli.cli import plugin_manager`). This gives commands access to the actual loaded state rather than a freshly constructed manager.
+- Before doing any work, check `plugin_manager.plugins_dir_exists`. If false, print a clear error: `Plugin directory not initialized. Run "xsoar-cli plugins init" to set up the plugins directory.` and exit with code 1.
+- Add `-> None` return type annotations to all command functions.
+- Defer the `PluginManager` import (for `init`, which still needs the class to know the default path) into the function body with the `# Lazy import for performance reasons` comment.
+- Remove the top-level `from xsoar_cli.plugins.manager import PluginManager` import.
+- Make `@click.pass_context` usage consistent: add it to commands that need `ctx` for exit codes, remove it from commands that don't use `ctx`.
+
+### Implementation notes
+
+The `validate` command currently imports `CORE_COMMANDS` from `xsoar_cli.cli` and reconstructs a temporary Click group to check conflicts. With access to the real `plugin_manager`, this can be simplified: the manager already tracks `command_conflicts` from the startup registration. `validate` can just read that list and re-run `load_plugin` + `get_command` validation per plugin.
+
+The `info` command currently catches bare `Exception`. After the refactor it will access the already-loaded plugin from `plugin_manager.loaded_plugins` (or report it as failed if it's in `plugin_manager.failed_plugins`), removing the need for a try/except around loading.
+
+### Files modified
+
+- `src/xsoar_cli/commands/plugins/commands.py`
+
+## Step 4: Update `cli.py`
+
+Adjust startup plugin loading to handle missing directory gracefully.
+
+### Changes
+
+- In `_load_plugins`, the `PluginManager` constructor no longer creates the directory or modifies `sys.path`. If the directory doesn't exist, `discover_plugins` returns an empty list and `load_all_plugins` returns an empty dict. No plugins are registered. Log a debug message: `"Plugins directory not found, skipping plugin loading"`.
+- Remove the `click.echo` warning for failed plugin registration in `_load_plugins`. Replace with `logger.warning` calls. (At this point in startup, logging is not yet configured for the file handler, but the message will be visible if `--debug` is used. This matches the existing pattern where module-level code avoids `click.echo` side effects.)
+- In `XSOARCliGroup.resolve_command`, handle the case where no plugins directory exists. Currently it checks `plugin_manager.get_failed_plugins()` and reports them. After the refactor, if the directory doesn't exist, `failed_plugins` will be empty and the error falls through to the normal "No such command" message, which is correct.
+
+### Implementation notes
+
+The module-level `plugin_manager` remains a `PluginManager` instance regardless of whether the directory exists. Commands access it via `from xsoar_cli.cli import plugin_manager`. The `plugins_dir_exists` property on the manager is the canonical way to check initialization state.
+
+### Files modified
+
+- `src/xsoar_cli/cli.py`
+
+## Step 5: Refactor tests
+
+Align plugin tests with the project's test conventions.
+
+### CLI tests (`tests/cli/test_plugins.py`)
+
+- Introduce a `mock_plugin_env` composite fixture in `tests/cli/conftest.py`. It should yield a `SimpleNamespace` with attributes for the mocked `plugin_manager` and its sub-mocks (loaded plugins, failed plugins, plugin info, etc.).
+- Replace `@patch` decorator stacking in `TestPluginCommands` with the new fixture.
+- Add test cases for the new `plugins init` command (directory creation, example plugin written, already-exists prompt).
+- Add test cases for the "not initialized" error path on `list`, `info`, and `validate`.
+- Add a test verifying that `plugins init` followed by `plugins list` shows the hello plugin.
+
+### Unit tests (`tests/unit/test_plugin_manager.py`)
+
+- Replace `tempfile.TemporaryDirectory()` context managers with pytest's `tmp_path` fixture.
+- Add a test for `plugins_dir_exists` returning `False` when the directory is missing.
+- Add a test for `discover_plugins` returning an empty list when the directory is missing (without raising).
+- Update `TestPluginConflicts.test_command_conflict_detection` to use an explicit `from xsoar_cli.plugins import XSOARPlugin` import in the plugin content string (matching the new requirement).
+- Align test class and method naming with the conventions in other unit test files.
+
+### Files modified
+
+- `tests/cli/conftest.py` (add `mock_plugin_env` fixture)
+- `tests/cli/test_plugins.py`
+- `tests/unit/test_plugin_manager.py`
+
+## Step 6: Update documentation
+
+### `src/xsoar_cli/plugins/README.md`
+
+- Add `xsoar-cli plugins init` as the first step in the Quick Start section.
+- Update the example plugin to include `from xsoar_cli.plugins import XSOARPlugin`.
+- Remove the sentence "The XSOARPlugin base class is automatically available in plugin files without any imports."
+- Add a "Limitations" section stating that each plugin must be a single self-contained `.py` file and that imports between plugin files in the plugins directory are not supported.
+
+### `src/xsoar_cli/commands/plugins/README.md`
+
+- Add documentation for the `init` subcommand with syntax, description, and examples.
+
+### `CHANGELOG.md`
+
+Add entries under `[Unreleased]`:
+
+- **Added**: `plugins init` command to create the plugins directory and generate an example plugin.
+- **Changed**: Plugin commands (`list`, `info`, `validate`) now report a clear error when the plugins directory has not been initialized.
+- **Changed**: Plugins must explicitly import `XSOARPlugin` (`from xsoar_cli.plugins import XSOARPlugin`). The base class is no longer injected automatically.
+- **Removed**: Automatic creation of the plugins directory on CLI startup.

--- a/src/xsoar_cli/cli.py
+++ b/src/xsoar_cli/cli.py
@@ -83,13 +83,29 @@ def _load_plugins() -> tuple[list[str], PluginManager]:
     """Captures core command names, then loads and registers plugins. Returns both."""
     core_commands = list(cli.commands.keys())
     manager = PluginManager()
-    try:
-        manager.load_all_plugins(ignore_errors=True)
-        for plugin_name, error in manager.get_failed_plugins().items():
-            click.echo(f"Warning: plugin '{plugin_name}' failed to load: {error}", err=True)
-        manager.register_plugin_commands(cli)
-    except Exception as e:
-        click.echo(f"Warning: failed to register plugin commands: {e}", err=True)
+
+    if not manager.plugins_dir_exists:
+        logging.getLogger(__name__).debug("Plugins directory not found, skipping plugin loading")
+        return core_commands, manager
+
+    manager.load_all_plugins(ignore_errors=True)
+
+    # Report load failures on stderr. These warnings run at module level before
+    # logging is configured, so logger.warning would be invisible. Plugin load
+    # failures are important enough to surface unconditionally.
+    load_failures = set(manager.get_failed_plugins().keys())
+    for plugin_name, error in manager.get_failed_plugins().items():
+        click.echo(f"Warning: plugin '{plugin_name}' failed to load: {error}", err=True)
+
+    manager.register_plugin_commands(cli)
+
+    # Registration failures are recorded in failed_plugins by the manager
+    # (skip-and-record pattern). Report only the new ones added during registration.
+    for plugin_name, error in manager.get_failed_plugins().items():
+        if plugin_name in load_failures:
+            continue  # Already reported above
+        click.echo(f"Warning: plugin '{plugin_name}' failed to register: {error}", err=True)
+
     return core_commands, manager
 
 

--- a/src/xsoar_cli/commands/plugins/README.md
+++ b/src/xsoar_cli/commands/plugins/README.md
@@ -2,6 +2,19 @@
 
 Manage plugins loaded into the CLI.
 
+## Init
+
+Initialize the plugins directory and generate an example plugin.
+
+**Syntax:** `xsoar-cli plugins init`
+
+Creates `~/.local/xsoar-cli/plugins/` (if it does not exist) and writes an example `hello.py` plugin. If the example file already exists, prompts for confirmation before overwriting.
+
+**Examples:**
+```
+xsoar-cli plugins init
+```
+
 ## List
 
 List all available and loaded plugins.
@@ -41,5 +54,3 @@ Validate all plugins in the plugins directory. Checks that each plugin can load 
 ```
 xsoar-cli plugins validate
 ```
-
-

--- a/src/xsoar_cli/commands/plugins/commands.py
+++ b/src/xsoar_cli/commands/plugins/commands.py
@@ -61,12 +61,13 @@ class HelloPlugin(XSOARPlugin):
 
         return hello
 
-    # You can also override the optional initialize() method on your plugin
-    # class if it needs setup work (open files, check credentials, etc.).
-    # It is called once, right after the plugin is instantiated:
-    #
-    #     def initialize(self) -> None:
-    #         ...
+    def initialize(self) -> None:
+        """Optional setup hook. Called once, right after the plugin is instantiated.
+
+        Override this method if your plugin needs setup work (open files,
+        check credentials, etc.). Safe to remove if not needed.
+        """
+        pass
 '''
 
 _NOT_INITIALIZED_MSG = 'Plugin directory not initialized. Run "xsoar-cli plugins init" to set up the plugins directory.'

--- a/src/xsoar_cli/commands/plugins/commands.py
+++ b/src/xsoar_cli/commands/plugins/commands.py
@@ -61,8 +61,8 @@ class HelloPlugin(XSOARPlugin):
 
         return hello
 
-    # There is also an optional initialize() method you can override if
-    # your plugin needs setup work (open files, check credentials, etc.).
+    # You can also override the optional initialize() method on your plugin
+    # class if it needs setup work (open files, check credentials, etc.).
     # It is called once, right after the plugin is instantiated:
     #
     #     def initialize(self) -> None:

--- a/src/xsoar_cli/commands/plugins/commands.py
+++ b/src/xsoar_cli/commands/plugins/commands.py
@@ -13,24 +13,45 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _EXAMPLE_PLUGIN = '''\
+# Example xsoar-cli plugin.
+#
+# Plugin files are Python modules placed in this directory. Each file is
+# discovered and loaded automatically when the CLI starts. To create your
+# own plugin, copy this file or replace it entirely.
+#
+# For more details see: xsoar-cli plugins --help
+
 import click
 
+# Every plugin must explicitly import the base class.
 from xsoar_cli.plugins import XSOARPlugin
 
 
+# Define a class that inherits from XSOARPlugin. The CLI will find it
+# automatically (you can name the class anything you like).
 class HelloPlugin(XSOARPlugin):
+
+    # Unique identifier for this plugin. Used as the key in "plugins list"
+    # and "plugins info <name>".
     @property
     def name(self) -> str:
         return "hello"
 
+    # Version string shown in "plugins list" and "plugins info".
     @property
     def version(self) -> str:
         return "1.0.0"
 
+    # Optional human-readable summary. Shown in "plugins info" and in
+    # verbose output of "plugins list". Return None (or omit entirely)
+    # if you do not need a description.
     @property
     def description(self) -> str:
         return "Example plugin. Modify or replace this file."
 
+    # Return a Click command (or group) to register on the CLI. The
+    # command name becomes the top-level subcommand users invoke, e.g.
+    # "xsoar-cli hello --name Alice".
     def get_command(self) -> click.Command:
         @click.command()
         @click.option("--name", default="World", help="Name to greet")
@@ -39,6 +60,13 @@ class HelloPlugin(XSOARPlugin):
             click.echo(f"Hello, {name}!")
 
         return hello
+
+    # There is also an optional initialize() method you can override if
+    # your plugin needs setup work (open files, check credentials, etc.).
+    # It is called once, right after the plugin is instantiated:
+    #
+    #     def initialize(self) -> None:
+    #         ...
 '''
 
 _NOT_INITIALIZED_MSG = 'Plugin directory not initialized. Run "xsoar-cli plugins init" to set up the plugins directory.'

--- a/src/xsoar_cli/commands/plugins/commands.py
+++ b/src/xsoar_cli/commands/plugins/commands.py
@@ -1,7 +1,5 @@
 """Plugin management commands for XSOAR CLI."""
 
-from __future__ import annotations
-
 import logging
 from typing import TYPE_CHECKING
 
@@ -87,11 +85,12 @@ def _get_plugin_manager():  # noqa: ANN202
 @click.group()
 def plugins() -> None:
     """Manage XSOAR CLI plugins."""
+    pass
 
 
-@click.command(help="Initialize the plugins directory with an example plugin")
+@click.command()
 def init() -> None:
-    """Create the plugins directory and write an example plugin."""
+    """Initialize the plugins directory and write an example plugin."""
     from xsoar_cli.plugins.manager import PluginManager  # Lazy import for performance reasons
 
     plugins_dir: Path = PluginManager.DEFAULT_PLUGINS_DIR
@@ -111,7 +110,7 @@ def init() -> None:
     click.echo(f"Wrote example plugin: {example_file}")
 
 
-@click.command(help="List all available and loaded plugins")
+@click.command()
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed information")
 def list_plugins(verbose: bool) -> None:
     """List all plugins in the plugins directory."""
@@ -161,7 +160,7 @@ def list_plugins(verbose: bool) -> None:
             click.echo("    Solution: Rename the command in your plugin or use a command group")
 
 
-@click.command(help="Show information about a specific plugin")
+@click.command()
 @click.argument("plugin_name", type=str)
 @click.pass_context
 def info(ctx: click.Context, plugin_name: str) -> None:
@@ -194,14 +193,14 @@ def info(ctx: click.Context, plugin_name: str) -> None:
         command = plugin.get_command()
         click.echo(f"  Command: {command.name}")
         if hasattr(command, "commands"):
-            subcommands = list(command.commands.keys())  # ty: ignore[unresolved-attribute]
+            subcommands = list(command.commands.keys())
             if subcommands:
                 click.echo(f"  Subcommands: {', '.join(subcommands)}")
     except Exception as e:
         click.echo(f"  Command: Error loading command ({e})")
 
 
-@click.command(help="Validate all plugins")
+@click.command()
 @click.pass_context
 def validate(ctx: click.Context) -> None:
     """Validate all plugins in the plugins directory."""

--- a/src/xsoar_cli/commands/plugins/commands.py
+++ b/src/xsoar_cli/commands/plugins/commands.py
@@ -64,8 +64,8 @@ class HelloPlugin(XSOARPlugin):
     def initialize(self) -> None:
         """Optional setup hook. Called once, right after the plugin is instantiated.
 
-        Override this method if your plugin needs setup work (open files,
-        check credentials, etc.). Safe to remove if not needed.
+        In this method you might want to add setup work like opening files, checking
+        credentials, etc. It's safe to remove this method if you don't need it.
         """
         pass
 '''

--- a/src/xsoar_cli/commands/plugins/commands.py
+++ b/src/xsoar_cli/commands/plugins/commands.py
@@ -1,50 +1,109 @@
-"""
-Plugin management commands for XSOAR CLI
+"""Plugin management commands for XSOAR CLI."""
 
-This module provides CLI commands for managing plugins, including
-listing, loading, reloading, and creating example plugins.
-"""
+from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import click
 
-from xsoar_cli.plugins.manager import PluginManager
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+_EXAMPLE_PLUGIN = '''\
+import click
+
+from xsoar_cli.plugins import XSOARPlugin
+
+
+class HelloPlugin(XSOARPlugin):
+    @property
+    def name(self) -> str:
+        return "hello"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    @property
+    def description(self) -> str:
+        return "Example plugin. Modify or replace this file."
+
+    def get_command(self) -> click.Command:
+        @click.command()
+        @click.option("--name", default="World", help="Name to greet")
+        def hello(name: str) -> None:
+            """Say hello."""
+            click.echo(f"Hello, {name}!")
+
+        return hello
+'''
+
+_NOT_INITIALIZED_MSG = 'Plugin directory not initialized. Run "xsoar-cli plugins init" to set up the plugins directory.'
+
+
+def _get_plugin_manager():  # noqa: ANN202
+    """Return the module-level plugin_manager from cli.py.
+
+    This import is deferred into the function body to avoid a circular import
+    (cli.py imports this module at module level via _register_commands).
+    """
+    from xsoar_cli.cli import plugin_manager  # Lazy import for performance reasons
+
+    return plugin_manager
+
 
 @click.group()
-def plugins():
-    """Manage XSOAR CLI plugins"""
-    pass
+def plugins() -> None:
+    """Manage XSOAR CLI plugins."""
+
+
+@click.command(help="Initialize the plugins directory with an example plugin")
+def init() -> None:
+    """Create the plugins directory and write an example plugin."""
+    from xsoar_cli.plugins.manager import PluginManager  # Lazy import for performance reasons
+
+    plugins_dir: Path = PluginManager.DEFAULT_PLUGINS_DIR
+    example_file = plugins_dir / "hello.py"
+
+    if plugins_dir.exists():
+        if example_file.exists():
+            click.confirm(
+                f"Example plugin already exists at {example_file}. Overwrite?",
+                abort=True,
+            )
+    else:
+        plugins_dir.mkdir(parents=True, exist_ok=True)
+        click.echo(f"Created plugins directory: {plugins_dir}")
+
+    example_file.write_text(_EXAMPLE_PLUGIN)
+    click.echo(f"Wrote example plugin: {example_file}")
 
 
 @click.command(help="List all available and loaded plugins")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed information")
-@click.pass_context
-def list_plugins(ctx: click.Context, verbose: bool):
+def list_plugins(verbose: bool) -> None:
     """List all plugins in the plugins directory."""
-    plugin_manager = PluginManager()
+    plugin_manager = _get_plugin_manager()
 
-    # Discover all plugins
-    discovered = plugin_manager.discover_plugins()
-
-    # Load all plugins to get their info
-    plugin_manager.load_all_plugins(ignore_errors=True)
+    if not plugin_manager.plugins_dir_exists:
+        click.echo(_NOT_INITIALIZED_MSG, err=True)
+        raise SystemExit(1)
 
     loaded_info = plugin_manager.get_plugin_info()
     failed_info = plugin_manager.get_failed_plugins()
 
-    if not discovered:
+    if not loaded_info and not failed_info:
+        click.echo(f"No plugins found in {plugin_manager.plugins_dir}")
         return
 
     click.echo(f"Plugins directory: {plugin_manager.plugins_dir}")
-    click.echo(f"Discovered {len(discovered)} plugin files\n")
 
     # Show loaded plugins
     if loaded_info:
-        click.echo("Loaded Plugins:")
+        click.echo("\nLoaded Plugins:")
         for plugin_name, info in loaded_info.items():
             if verbose:
                 click.echo(f"  {plugin_name}")
@@ -53,30 +112,20 @@ def list_plugins(ctx: click.Context, verbose: bool):
                 click.echo(f"    Description: {info['description']}")
             else:
                 click.echo(f"  {plugin_name} (v{info['version']})")
-        click.echo()
 
     # Show failed plugins
     if failed_info:
-        click.echo("Failed Plugins:")
+        click.echo("\nFailed Plugins:")
         for plugin_name, error in failed_info.items():
             if verbose:
                 click.echo(f"  {plugin_name}: {error}")
             else:
                 click.echo(f"  {plugin_name}")
-        click.echo()
-
-    # Show unloaded plugins (discovered but not loaded and not failed)
-    unloaded = set(discovered) - set(loaded_info.keys()) - set(failed_info.keys())
-    if unloaded:
-        click.echo("Unloaded Plugins:")
-        for plugin_name in unloaded:
-            click.echo(f"  {plugin_name}")
 
     # Show command conflicts
     conflicts = plugin_manager.get_command_conflicts()
     if conflicts:
-        click.echo()
-        click.echo("Command Conflicts:")
+        click.echo("\nCommand Conflicts:")
         for conflict in conflicts:
             click.echo(f"  Plugin '{conflict['plugin_name']}' command '{conflict['command_name']}' conflicts with core command")
             click.echo(f"    Plugin version: {conflict['plugin_version']}")
@@ -85,92 +134,86 @@ def list_plugins(ctx: click.Context, verbose: bool):
 
 @click.command(help="Show information about a specific plugin")
 @click.argument("plugin_name", type=str)
-def info(plugin_name: str):
+@click.pass_context
+def info(ctx: click.Context, plugin_name: str) -> None:
     """Show detailed information about a plugin."""
-    plugin_manager = PluginManager()
+    plugin_manager = _get_plugin_manager()
+
+    if not plugin_manager.plugins_dir_exists:
+        click.echo(_NOT_INITIALIZED_MSG, err=True)
+        ctx.exit(1)
+        return
+
+    if plugin_name not in plugin_manager.loaded_plugins:
+        failed = plugin_manager.get_failed_plugins()
+        if plugin_name in failed:
+            click.echo(f"Plugin '{plugin_name}' failed to load: {failed[plugin_name]}")
+        else:
+            click.echo(f"Plugin not found: {plugin_name}")
+        ctx.exit(1)
+        return
+
+    plugin = plugin_manager.loaded_plugins[plugin_name]
+
+    click.echo("Plugin Information:")
+    click.echo(f"  File: {plugin_manager.plugins_dir / f'{plugin_name}.py'}")
+    click.echo(f"  Name: {plugin.name}")
+    click.echo(f"  Version: {plugin.version}")
+    click.echo(f"  Description: {plugin.description or 'No description provided'}")
 
     try:
-        plugin = plugin_manager.load_plugin(plugin_name)
-
-        if plugin:
-            click.echo("Plugin Information:")
-            click.echo(f"  File: {plugin_manager.plugins_dir / plugin_name}.py")
-            click.echo(f"  Name: {plugin.name}")
-            click.echo(f"  Version: {plugin.version}")
-            click.echo(f"  Description: {plugin.description or 'No description provided'}")
-
-            # Try to get command info
-            try:
-                command = plugin.get_command()
-                click.echo(f"  Command: {command.name}")
-                if hasattr(command, "commands"):
-                    subcommands = list(command.commands.keys())  # ty: ignore[unresolved-attribute]
-                    if subcommands:
-                        click.echo(f"  Subcommands: {', '.join(subcommands)}")
-            except Exception as e:
-                click.echo(f"  Command: Error loading command ({e})")
-        else:
-            click.echo(f"Plugin not found or failed to load: {plugin_name}")
-
+        command = plugin.get_command()
+        click.echo(f"  Command: {command.name}")
+        if hasattr(command, "commands"):
+            subcommands = list(command.commands.keys())  # ty: ignore[unresolved-attribute]
+            if subcommands:
+                click.echo(f"  Subcommands: {', '.join(subcommands)}")
     except Exception as e:
-        click.echo(f"Error loading plugin {plugin_name}: {e}")
+        click.echo(f"  Command: Error loading command ({e})")
 
 
 @click.command(help="Validate all plugins")
-def validate():
+@click.pass_context
+def validate(ctx: click.Context) -> None:
     """Validate all plugins in the plugins directory."""
-    plugin_manager = PluginManager()
+    plugin_manager = _get_plugin_manager()
 
-    discovered = plugin_manager.discover_plugins()
+    if not plugin_manager.plugins_dir_exists:
+        click.echo(_NOT_INITIALIZED_MSG, err=True)
+        ctx.exit(1)
+        return
 
-    if not discovered:
+    loaded = plugin_manager.loaded_plugins
+    failed = plugin_manager.get_failed_plugins()
+
+    if not loaded and not failed:
         click.echo(f"No plugins found in {plugin_manager.plugins_dir}")
         return
 
-    click.echo(f"Validating {len(discovered)} plugins...\n")
-
     all_valid = True
 
-    for plugin_name in discovered:
+    for plugin_name, plugin in loaded.items():
         try:
-            plugin = plugin_manager.load_plugin(plugin_name)
-            if plugin:
-                # Test that the plugin can provide a command
-                command = plugin.get_command()
-                if not isinstance(command, (click.Command, click.Group)):
-                    raise ValueError("get_command() must return a Click Command or Group")
-
-                click.echo(f"{plugin_name}: Valid")
-            else:
-                click.echo(f"{plugin_name}: Failed to load")
-                all_valid = False
-
+            command = plugin.get_command()
+            if not isinstance(command, (click.Command, click.Group)):
+                raise ValueError("get_command() must return a Click Command or Group")
+            click.echo(f"{plugin_name}: Valid")
         except Exception as e:
             click.echo(f"{plugin_name}: {e}")
             all_valid = False
 
-    # Check for command conflicts by attempting registration against a temporary
-    # CLI group containing only core commands. Using the real cli object is wrong
-    # because plugin commands are already registered on it at startup, which causes
-    # them to be falsely reported as conflicts.
-    try:
-        from xsoar_cli.cli import CORE_COMMANDS
+    for plugin_name, error in failed.items():
+        click.echo(f"{plugin_name}: {error}")
+        all_valid = False
 
-        temp_cli = click.Group()
-        for cmd_name in CORE_COMMANDS:
-            temp_cli.add_command(click.Command(cmd_name, callback=lambda: None))
-
-        plugin_manager.register_plugin_commands(temp_cli)
-
-        conflicts = plugin_manager.get_command_conflicts()
-        if conflicts:
-            click.echo("\nCommand Conflicts Detected:")
-            for conflict in conflicts:
-                click.echo(f"  Plugin '{conflict['plugin_name']}' command '{conflict['command_name']}' conflicts with core command")
-                click.echo("    Solution: Rename the command or use a command group")
-            all_valid = False
-    except Exception as e:
-        click.echo(f"\nCould not check for command conflicts: {e}")
+    # Report conflicts recorded at startup
+    conflicts = plugin_manager.get_command_conflicts()
+    if conflicts:
+        click.echo("\nCommand Conflicts Detected:")
+        for conflict in conflicts:
+            click.echo(f"  Plugin '{conflict['plugin_name']}' command '{conflict['command_name']}' conflicts with core command")
+            click.echo("    Solution: Rename the command or use a command group")
+        all_valid = False
 
     click.echo()
     if all_valid:
@@ -179,7 +222,8 @@ def validate():
         click.echo("Some plugins have validation errors.")
 
 
-# Add all commands to the plugins group
+# Register subcommands
+plugins.add_command(init)
 plugins.add_command(list_plugins, name="list")
 plugins.add_command(info)
 plugins.add_command(validate)

--- a/src/xsoar_cli/plugins/README.md
+++ b/src/xsoar_cli/plugins/README.md
@@ -4,14 +4,17 @@ Plugins are Python files placed in `~/.local/xsoar-cli/plugins/` that are automa
 
 ## Quick Start
 
-1. Create the plugins directory:
+1. Initialize the plugins directory:
    ```
-   mkdir -p ~/.local/xsoar-cli/plugins
+   xsoar-cli plugins init
    ```
+   This creates `~/.local/xsoar-cli/plugins/` and writes an example `hello.py` plugin.
 
 2. Create a plugin file (`~/.local/xsoar-cli/plugins/hello_plugin.py`):
    ```python
    import click
+
+   from xsoar_cli.plugins import XSOARPlugin
 
    class HelloPlugin(XSOARPlugin):
        @property
@@ -37,7 +40,11 @@ Plugins are Python files placed in `~/.local/xsoar-cli/plugins/` that are automa
 
 ## Plugin Structure
 
-A plugin must be a Python class that inherits from `XSOARPlugin`. The `XSOARPlugin` base class is automatically available in plugin files without any imports.
+A plugin must be a Python class that inherits from `XSOARPlugin` and imports it explicitly:
+
+```python
+from xsoar_cli.plugins import XSOARPlugin
+```
 
 **Required methods:**
 - `name` - Unique identifier for your plugin
@@ -50,4 +57,10 @@ A plugin must be a Python class that inherits from `XSOARPlugin`. The `XSOARPlug
 
 ## Command Conflicts
 
-Plugin commands cannot use the same names as core CLI commands (`case`, `config`, `graph`, `integration`, `manifest`, `pack`, `playbook`, `plugins`, `rbac`). If a conflict is detected, the plugin command is skipped. Use a different command name or wrap your commands in a Click group.
+Plugin commands cannot use the same names as core CLI commands (`case`, `completions`, `config`, `content`, `graph`, `integration`, `manifest`, `pack`, `plugins`, `rbac`). If a conflict is detected, the plugin command is skipped. Use a different command name or wrap your commands in a Click group.
+
+## Limitations
+
+- Each plugin must be a single self-contained `.py` file.
+- Imports between plugin files in the plugins directory are not supported.
+- Plugin file names must not collide with Python standard library module names or installed packages (e.g., do not name a plugin `json.py` or `logging.py`).

--- a/src/xsoar_cli/plugins/README.md
+++ b/src/xsoar_cli/plugins/README.md
@@ -10,30 +10,7 @@ Plugins are Python files placed in `~/.local/xsoar-cli/plugins/` that are automa
    ```
    This creates `~/.local/xsoar-cli/plugins/` and writes an example `hello.py` plugin.
 
-2. Create a plugin file (`~/.local/xsoar-cli/plugins/hello_plugin.py`):
-   ```python
-   import click
-
-   from xsoar_cli.plugins import XSOARPlugin
-
-   class HelloPlugin(XSOARPlugin):
-       @property
-       def name(self) -> str:
-           return "hello"
-
-       @property
-       def version(self) -> str:
-           return "1.0.0"
-
-       def get_command(self) -> click.Command:
-           @click.command(help="Say hello")
-           @click.option("--name", default="World", help="Name to greet")
-           def hello(name: str):
-               click.echo(f"Hello, {name}!")
-           return hello
-   ```
-
-3. Use your plugin:
+2. Use your plugin:
    ```
    xsoar-cli hello --name "Alice"
    ```

--- a/src/xsoar_cli/plugins/__init__.py
+++ b/src/xsoar_cli/plugins/__init__.py
@@ -1,23 +1,14 @@
-"""
-XSOAR CLI Plugin System
+"""Plugin infrastructure for extending the CLI with custom commands."""
 
-This module provides the infrastructure for creating and loading plugins
-for the xsoar-cli application. Plugins can extend the CLI with custom
-commands and functionality.
-"""
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
 
 import click
 
 
 class XSOARPlugin(ABC):
-    """
-    Abstract base class for XSOAR CLI plugins.
-
-    All plugins should inherit from this class and implement the required methods.
-    """
+    """Base class for CLI plugins."""
 
     @property
     @abstractmethod
@@ -30,33 +21,28 @@ class XSOARPlugin(ABC):
         """Return the plugin version."""
 
     @property
-    def description(self) -> Optional[str]:
+    def description(self) -> str | None:
         """Return an optional description of the plugin."""
         return None
 
     @abstractmethod
     def get_command(self) -> click.Command:
-        """
-        Return the Click command or command group that this plugin provides.
-
-        Returns:
-            click.Command: The command to be registered with the CLI
-        """
+        """Return the Click command or group that this plugin provides."""
 
     def initialize(self) -> None:
-        """
-        Initialize the plugin. Called once when the plugin is loaded.
+        """Initialize the plugin. Called once when the plugin is loaded.
+
         Override this method if your plugin needs initialization.
         """
 
 
 class PluginError(Exception):
-    """Exception raised when there's an error with plugin loading or execution."""
+    """Base exception for plugin errors."""
 
 
 class PluginLoadError(PluginError):
-    """Exception raised when a plugin fails to load."""
+    """Raised when a plugin fails to load."""
 
 
 class PluginRegistrationError(PluginError):
-    """Exception raised when a plugin fails to register."""
+    """Raised when a plugin fails to register its command."""

--- a/src/xsoar_cli/plugins/manager.py
+++ b/src/xsoar_cli/plugins/manager.py
@@ -1,96 +1,84 @@
-"""
-Plugin Manager for XSOAR CLI
+"""Plugin manager: discovery, loading, and registration of CLI plugins."""
 
-This module handles the discovery, loading, and management of plugins
-for the xsoar-cli application from a local directory.
-"""
+from __future__ import annotations
 
 import importlib.util
 import logging
-import sys
 import types
 from pathlib import Path
-
-import click
+from typing import TYPE_CHECKING
 
 from . import PluginLoadError, PluginRegistrationError, XSOARPlugin
+
+if TYPE_CHECKING:
+    import click
 
 logger = logging.getLogger(__name__)
 
 
 class PluginManager:
-    """Manages the discovery, loading, and registration of XSOAR CLI plugins from the plugins directory."""
+    """Discovers, loads, and registers plugins from a local directory."""
+
+    DEFAULT_PLUGINS_DIR: Path = Path.home() / ".local" / "xsoar-cli" / "plugins"
 
     def __init__(self, plugins_dir: Path | None = None) -> None:
-        """Defaults to ~/.local/xsoar-cli/plugins if no directory is provided."""
-        if plugins_dir is None:
-            self.plugins_dir = Path.home() / ".local" / "xsoar-cli" / "plugins"
-        else:
-            self.plugins_dir = plugins_dir
-
+        """Defaults to ``DEFAULT_PLUGINS_DIR`` if no directory is provided."""
+        self.plugins_dir = plugins_dir if plugins_dir is not None else self.DEFAULT_PLUGINS_DIR
         self.loaded_plugins: dict[str, XSOARPlugin] = {}
         self.failed_plugins: dict[str, Exception] = {}
         self.command_conflicts: list[dict[str, str]] = []
 
-        # Ensure plugins directory exists
-        self.plugins_dir.mkdir(parents=True, exist_ok=True)
-
-        # Add plugins directory to Python path if not already there
-        plugins_dir_str = str(self.plugins_dir)
-        if plugins_dir_str not in sys.path:
-            sys.path.insert(0, plugins_dir_str)
+    @property
+    def plugins_dir_exists(self) -> bool:
+        """Return ``True`` if the plugins directory exists on disk."""
+        return self.plugins_dir.exists()
 
     def discover_plugins(self) -> list[str]:
-        """Scans the plugins directory for Python files and returns their module names."""
+        """Scan the plugins directory for Python files and return their module names."""
+        if not self.plugins_dir_exists:
+            logger.debug("Plugins directory does not exist: %s", self.plugins_dir)
+            return []
+
         plugin_names = []
-
-        if not self.plugins_dir.exists():
-            logger.info("Plugins directory does not exist: %s", self.plugins_dir)
-            return plugin_names
-
         for file_path in self.plugins_dir.glob("*.py"):
             if file_path.name.startswith("__"):
                 continue  # Skip __init__.py, __pycache__, etc.
+            plugin_names.append(file_path.stem)
 
-            module_name = file_path.stem
-            plugin_names.append(module_name)
-
-        logger.info("Discovered %d plugin file(s): %s", len(plugin_names), plugin_names)
+        logger.debug("Discovered %d plugin file(s): %s", len(plugin_names), plugin_names)
         return plugin_names
 
     def _load_module_from_file(self, module_name: str, file_path: Path) -> types.ModuleType:
-        """Loads a Python module from disk and injects XSOARPlugin into its namespace so plugins do not need to import it explicitly."""
+        """Load a Python module from a file path."""
         spec = importlib.util.spec_from_file_location(module_name, file_path)
         if spec is None or spec.loader is None:
             raise PluginLoadError(f"Could not load module spec for {file_path}")
 
         module = importlib.util.module_from_spec(spec)
 
-        # Inject XSOARPlugin class into the module's namespace
-        # This allows plugins to use XSOARPlugin without complex imports
-        from . import XSOARPlugin
+        try:
+            spec.loader.exec_module(module)
+        except NameError as e:
+            if "XSOARPlugin" in str(e):
+                raise PluginLoadError(
+                    f"Plugin '{module_name}' uses XSOARPlugin without importing it. "
+                    "Add 'from xsoar_cli.plugins import XSOARPlugin' to your plugin file."
+                ) from e
+            raise
 
-        setattr(module, "XSOARPlugin", XSOARPlugin)
-
-        sys.modules[module_name] = module
-        spec.loader.exec_module(module)
         return module
 
     def _find_plugin_classes(self, module: types.ModuleType) -> list[type[XSOARPlugin]]:
-        """Returns all XSOARPlugin subclasses found in the given module."""
+        """Return all XSOARPlugin subclasses found in the given module."""
         plugin_classes = []
-
         for attr_name in dir(module):
             attr = getattr(module, attr_name)
-
-            # Check if it's a class that inherits from XSOARPlugin
             if isinstance(attr, type) and issubclass(attr, XSOARPlugin) and attr is not XSOARPlugin:
                 plugin_classes.append(attr)
-
         return plugin_classes
 
     def load_plugin(self, plugin_name: str) -> XSOARPlugin | None:
-        """Loads and initializes a single plugin by module name. Raises PluginLoadError on failure."""
+        """Load and initialize a single plugin by module name."""
         if plugin_name in self.loaded_plugins:
             return self.loaded_plugins[plugin_name]
 
@@ -99,16 +87,11 @@ class PluginManager:
             if not file_path.exists():
                 raise PluginLoadError(f"Plugin file not found: {file_path}")
 
-            # Load the module
             module = self._load_module_from_file(plugin_name, file_path)
 
-            # Find plugin classes in the module
             plugin_classes = self._find_plugin_classes(module)
-
             if not plugin_classes:
-                raise PluginLoadError(
-                    f"No XSOARPlugin classes found in {plugin_name}.py",
-                )
+                raise PluginLoadError(f"No XSOARPlugin classes found in {plugin_name}.py")
 
             if len(plugin_classes) > 1:
                 logger.warning(
@@ -116,20 +99,15 @@ class PluginManager:
                     plugin_name,
                 )
 
-            # Instantiate the first plugin class found
-            plugin_class = plugin_classes[0]
-            plugin_instance = plugin_class()
+            plugin_instance = plugin_classes[0]()
 
-            # Initialize the plugin
             try:
                 plugin_instance.initialize()
             except Exception as e:
                 raise PluginLoadError(f"Plugin '{plugin_name}' initialization failed: {e}")
 
-            # Store the loaded plugin
             self.loaded_plugins[plugin_name] = plugin_instance
-            logger.info("Successfully loaded plugin: %s", plugin_name)
-
+            logger.debug("Successfully loaded plugin: %s", plugin_name)
             return plugin_instance
 
         except Exception as e:
@@ -138,7 +116,11 @@ class PluginManager:
             raise PluginLoadError(f"Failed to load plugin '{plugin_name}': {e}")
 
     def load_all_plugins(self, *, ignore_errors: bool = True) -> dict[str, XSOARPlugin]:
-        """Loads all discovered plugins. By default, a failed plugin is recorded and skipped so remaining plugins can still load. Pass ignore_errors=False to abort on the first failure."""
+        """Load all discovered plugins.
+
+        By default, a failed plugin is recorded and skipped so remaining plugins
+        can still load. Pass ``ignore_errors=False`` to abort on the first failure.
+        """
         discovered_plugins = self.discover_plugins()
 
         for plugin_name in discovered_plugins:
@@ -152,18 +134,24 @@ class PluginManager:
         return self.loaded_plugins.copy()
 
     def register_plugin_commands(self, cli_group: click.Group) -> None:
-        """Registers each loaded plugin's command with the given Click group. Commands that conflict with an existing command are skipped and recorded in command_conflicts."""
-        conflicts = []
+        """Register each loaded plugin's command with the given Click group.
 
-        for plugin_name, plugin in self.loaded_plugins.items():
+        Commands that conflict with an existing command are skipped and recorded
+        in ``command_conflicts``. Registration failures are logged and recorded
+        in ``failed_plugins`` so remaining plugins can still register.
+        """
+        import click as _click  # Lazy import for performance reasons
+
+        conflicts: list[dict[str, str]] = []
+
+        for plugin_name, plugin in list(self.loaded_plugins.items()):
             try:
                 command = plugin.get_command()
-                if not isinstance(command, (click.Command, click.Group)):
+                if not isinstance(command, (_click.Command, _click.Group)):
                     raise PluginRegistrationError(
                         f"Plugin '{plugin_name}' get_command() must return a Click Command or Group",
                     )
 
-                # Ensure the command name doesn't conflict with existing commands
                 if command.name in cli_group.commands:
                     conflict_info = {
                         "plugin_name": plugin_name,
@@ -179,18 +167,16 @@ class PluginManager:
                     continue
 
                 cli_group.add_command(command)
-                logger.info("Registered command '%s' from plugin '%s'", command.name, plugin_name)
+                logger.debug("Registered command '%s' from plugin '%s'", command.name, plugin_name)
 
             except Exception as e:
-                error_msg = f"Failed to register plugin '{plugin_name}': {e}"
-                logger.debug("Failed to register plugin '%s': %s", plugin_name, e)
-                raise PluginRegistrationError(error_msg)
+                self.failed_plugins[plugin_name] = e
+                logger.warning("Failed to register plugin '%s': %s", plugin_name, e)
 
-        # Store conflicts for later reporting
         self.command_conflicts = conflicts
 
     def get_plugin_info(self) -> dict[str, dict[str, str]]:
-        """Returns name, version, and description for each loaded plugin."""
+        """Return name, version, and description for each loaded plugin."""
         info = {}
         for plugin_name, plugin in self.loaded_plugins.items():
             info[plugin_name] = {
@@ -201,9 +187,9 @@ class PluginManager:
         return info
 
     def get_failed_plugins(self) -> dict[str, str]:
-        """Returns a mapping of plugin names to their load error messages."""
+        """Return a mapping of plugin names to their error messages."""
         return {name: str(error) for name, error in self.failed_plugins.items()}
 
     def get_command_conflicts(self) -> list[dict[str, str]]:
-        """Returns any command conflicts detected during the last call to register_plugin_commands."""
+        """Return command conflicts detected during the last registration."""
         return self.command_conflicts.copy()

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -22,11 +22,6 @@ if TYPE_CHECKING:
     from click.testing import Result
 
 
-# ---------------------------------------------------------------------------
-# CLI invocation helper
-# ---------------------------------------------------------------------------
-
-
 class InvokeHelper:
     """Thin wrapper around ``CliRunner.invoke`` bound to the root CLI group.
 
@@ -54,11 +49,6 @@ def invoke() -> InvokeHelper:
             assert result.exit_code == 0
     """
     return InvokeHelper()
-
-
-# ---------------------------------------------------------------------------
-# Composite mock fixtures
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -135,11 +125,6 @@ def mock_content_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # no
         yield ns
 
 
-# ---------------------------------------------------------------------------
-# Plugin mock fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 def mock_plugin_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # noqa: ANN001
     """Mock environment for ``plugins`` CLI subcommands.
@@ -184,11 +169,6 @@ def mock_plugin_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # noq
             command_conflicts=mock_manager.command_conflicts,
         )
         yield ns
-
-
-# ---------------------------------------------------------------------------
-# Case-specific mock fixtures
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -6,8 +6,9 @@ convenience helpers that reduce boilerplate in CLI test modules.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -130,6 +131,57 @@ def mock_content_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # no
             attach=mock_attach,
             download_playbook=mock_dl_pb,
             download_layout=mock_dl_layout,
+        )
+        yield ns
+
+
+# ---------------------------------------------------------------------------
+# Plugin mock fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_plugin_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # noqa: ANN001
+    """Mock environment for ``plugins`` CLI subcommands.
+
+    Patches the module-level ``plugin_manager`` in ``cli.py`` so that plugin
+    commands (which obtain the manager via ``_get_plugin_manager()``) see a
+    controllable mock instead of the real instance.
+
+    Yields a ``SimpleNamespace`` with attributes:
+
+    * ``config`` -- the config file mock (from ``mock_config_file``)
+    * ``manager`` -- the ``MagicMock`` standing in for ``PluginManager``
+    * ``loaded_plugins`` -- shortcut dict for ``manager.loaded_plugins``
+    * ``failed_plugins`` -- shortcut dict for ``manager.failed_plugins``
+    * ``command_conflicts`` -- shortcut list for ``manager.command_conflicts``
+
+    Example::
+
+        def test_list_empty(invoke, mock_plugin_env):
+            mock_plugin_env.manager.plugins_dir_exists = True
+            result = invoke(["plugins", "list"])
+            assert "No plugins found" in result.output
+    """
+    import types as _types
+
+    mock_manager = MagicMock()
+    mock_manager.plugins_dir = Path("/test/plugins")
+    mock_manager.plugins_dir_exists = True
+    mock_manager.loaded_plugins = {}
+    mock_manager.failed_plugins = {}
+    mock_manager.command_conflicts = []
+    mock_manager.get_plugin_info.return_value = {}
+    mock_manager.get_failed_plugins.return_value = {}
+    mock_manager.get_command_conflicts.return_value = []
+
+    with patch.object(cli, "plugin_manager", mock_manager):
+        ns = _types.SimpleNamespace(
+            config=mock_config_file,
+            manager=mock_manager,
+            loaded_plugins=mock_manager.loaded_plugins,
+            failed_plugins=mock_manager.failed_plugins,
+            command_conflicts=mock_manager.command_conflicts,
         )
         yield ns
 

--- a/tests/cli/test_plugins.py
+++ b/tests/cli/test_plugins.py
@@ -2,103 +2,243 @@
 
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-from xsoar_cli.plugins.manager import PluginManager
+import click
 
 if TYPE_CHECKING:
     from tests.cli.conftest import InvokeHelper
 
 
-class TestPluginCommands:
-    """Tests for the ``plugins`` CLI subcommands."""
+class TestPluginsInit:
+    """Tests for the ``plugins init`` subcommand."""
 
-    @patch("xsoar_cli.commands.plugins.commands.PluginManager")
-    def test_plugins_list_command(self, mock_manager_class, invoke: InvokeHelper, mock_config_file) -> None:
-        mock_manager = MagicMock()
-        mock_manager_class.return_value = mock_manager
-        mock_manager.discover_plugins.return_value = ["test_plugin"]
-        mock_manager.get_plugin_info.return_value = {
+    def test_init_creates_directory_and_example(self, invoke: InvokeHelper, mock_config_file, tmp_path: Path) -> None:
+        plugins_dir = tmp_path / "plugins"
+        with patch("xsoar_cli.plugins.manager.PluginManager.DEFAULT_PLUGINS_DIR", plugins_dir):
+            result = invoke(["plugins", "init"])
+
+        assert result.exit_code == 0
+        assert plugins_dir.exists()
+        example_file = plugins_dir / "hello.py"
+        assert example_file.exists()
+        content = example_file.read_text()
+        assert "from xsoar_cli.plugins import XSOARPlugin" in content
+        assert "class HelloPlugin" in content
+        assert "Created plugins directory" in result.output
+        assert "Wrote example plugin" in result.output
+
+    def test_init_existing_directory_no_example(self, invoke: InvokeHelper, mock_config_file, tmp_path: Path) -> None:
+        """When the directory exists but the example file does not, write without prompting."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        with patch("xsoar_cli.plugins.manager.PluginManager.DEFAULT_PLUGINS_DIR", plugins_dir):
+            result = invoke(["plugins", "init"])
+
+        assert result.exit_code == 0
+        assert (plugins_dir / "hello.py").exists()
+        # Should NOT say "Created plugins directory" since it already existed.
+        assert "Created plugins directory" not in result.output
+
+    def test_init_overwrite_prompt_confirmed(self, invoke: InvokeHelper, mock_config_file, tmp_path: Path) -> None:
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        example_file = plugins_dir / "hello.py"
+        example_file.write_text("# old content")
+
+        with patch("xsoar_cli.plugins.manager.PluginManager.DEFAULT_PLUGINS_DIR", plugins_dir):
+            result = invoke(["plugins", "init"], input="y\n")
+
+        assert result.exit_code == 0
+        assert "class HelloPlugin" in example_file.read_text()
+
+    def test_init_overwrite_prompt_aborted(self, invoke: InvokeHelper, mock_config_file, tmp_path: Path) -> None:
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        example_file = plugins_dir / "hello.py"
+        example_file.write_text("# old content")
+
+        with patch("xsoar_cli.plugins.manager.PluginManager.DEFAULT_PLUGINS_DIR", plugins_dir):
+            result = invoke(["plugins", "init"], input="n\n")
+
+        assert result.exit_code == 1
+        assert example_file.read_text() == "# old content"
+
+
+class TestPluginsList:
+    """Tests for the ``plugins list`` subcommand."""
+
+    def test_list_not_initialized(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.plugins_dir_exists = False
+
+        result = invoke(["plugins", "list"])
+
+        assert result.exit_code == 1
+        assert "not initialized" in result.output.lower() or "not initialized" in (result.output + getattr(result, "stderr", "")).lower()
+
+    def test_list_empty_directory(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        result = invoke(["plugins", "list"])
+
+        assert result.exit_code == 0
+        assert "No plugins found" in result.output
+
+    def test_list_with_loaded_plugins(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.get_plugin_info.return_value = {
             "test_plugin": {
                 "name": "test",
                 "version": "1.0.0",
                 "description": "Test plugin",
             },
         }
-        mock_manager.get_failed_plugins.return_value = {}
-        mock_manager.plugins_dir = Path("/test/plugins")
 
         result = invoke(["plugins", "list"])
+
         assert result.exit_code == 0
         assert "test_plugin" in result.output
+        assert "1.0.0" in result.output
 
-    @patch("xsoar_cli.commands.plugins.commands.PluginManager")
-    def test_plugins_info_command(self, mock_manager_class, invoke: InvokeHelper, mock_config_file) -> None:
-        mock_manager = MagicMock()
-        mock_manager_class.return_value = mock_manager
+    def test_list_verbose(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.get_plugin_info.return_value = {
+            "test_plugin": {
+                "name": "test",
+                "version": "1.0.0",
+                "description": "Test plugin",
+            },
+        }
+
+        result = invoke(["plugins", "list", "--verbose"])
+
+        assert result.exit_code == 0
+        assert "Name: test" in result.output
+        assert "Version: 1.0.0" in result.output
+        assert "Description: Test plugin" in result.output
+
+    def test_list_with_failed_plugins(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.get_failed_plugins.return_value = {
+            "broken_plugin": "SyntaxError: invalid syntax",
+        }
+
+        result = invoke(["plugins", "list"])
+
+        assert result.exit_code == 0
+        assert "broken_plugin" in result.output
+
+    def test_list_with_conflicts(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.get_plugin_info.return_value = {
+            "my_plugin": {"name": "my", "version": "1.0.0", "description": "My plugin"},
+        }
+        mock_plugin_env.manager.get_command_conflicts.return_value = [
+            {"plugin_name": "my_plugin", "command_name": "case", "plugin_version": "1.0.0"},
+        ]
+
+        result = invoke(["plugins", "list"])
+
+        assert result.exit_code == 0
+        assert "Command Conflicts" in result.output
+        assert "case" in result.output
+
+
+class TestPluginsInfo:
+    """Tests for the ``plugins info`` subcommand."""
+
+    def test_info_not_initialized(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.plugins_dir_exists = False
+
+        result = invoke(["plugins", "info", "test_plugin"])
+
+        assert result.exit_code == 1
+
+    def test_info_plugin_not_found(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.get_failed_plugins.return_value = {}
+
+        result = invoke(["plugins", "info", "nonexistent"])
+
+        assert result.exit_code == 1
+        assert "Plugin not found" in result.output
+
+    def test_info_plugin_failed(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.get_failed_plugins.return_value = {
+            "broken": "SyntaxError: invalid syntax",
+        }
+
+        result = invoke(["plugins", "info", "broken"])
+
+        assert result.exit_code == 1
+        assert "failed to load" in result.output
+
+    def test_info_loaded_plugin(self, invoke: InvokeHelper, mock_plugin_env) -> None:
         mock_plugin = MagicMock()
         mock_plugin.name = "test"
         mock_plugin.version = "1.0.0"
         mock_plugin.description = "Test plugin"
-        mock_manager.load_plugin.return_value = mock_plugin
-        mock_manager.plugins_dir = Path("/test/plugins")
+        mock_command = click.Command("test", callback=lambda: None)
+        mock_plugin.get_command.return_value = mock_command
+
+        mock_plugin_env.manager.loaded_plugins["test_plugin"] = mock_plugin
+        mock_plugin_env.manager.plugins_dir = Path("/test/plugins")
 
         result = invoke(["plugins", "info", "test_plugin"])
+
         assert result.exit_code == 0
-        assert "test" in result.output
-        assert "1.0.0" in result.output
-
-    def test_plugins_validate_command(self, invoke: InvokeHelper, mock_config_file) -> None:
-        with patch("xsoar_cli.plugins.manager.PluginManager") as mock_manager_class:
-            mock_manager = MagicMock()
-            mock_manager_class.return_value = mock_manager
-            mock_manager.discover_plugins.return_value = ["test_plugin"]
-
-            mock_plugin = MagicMock()
-            mock_command = MagicMock()
-            mock_plugin.get_command.return_value = mock_command
-            mock_manager.load_plugin.return_value = mock_plugin
-
-            result = invoke(["plugins", "validate"])
-            assert result.exit_code == 0
-            assert "Valid" in result.output or "valid" in result.output or "No plugins found" in result.output
+        assert "Name: test" in result.output
+        assert "Version: 1.0.0" in result.output
+        assert "Description: Test plugin" in result.output
+        assert "File:" in result.output
+        assert "test_plugin.py" in result.output
 
 
-class TestPluginIntegration:
-    """Tests for plugin command registration with the CLI."""
+class TestPluginsValidate:
+    """Tests for the ``plugins validate`` subcommand."""
 
-    def test_plugin_command_registration(self, invoke: InvokeHelper, mock_config_file) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            plugins_dir = Path(temp_dir) / "plugins"
-            plugins_dir.mkdir()
+    def test_validate_not_initialized(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.plugins_dir_exists = False
 
-            plugin_content = """
-import click
-from xsoar_cli.plugins import XSOARPlugin
+        result = invoke(["plugins", "validate"])
 
-class TestPlugin(XSOARPlugin):
-    @property
-    def name(self):
-        return "test"
+        assert result.exit_code == 1
 
-    @property
-    def version(self):
-        return "1.0.0"
+    def test_validate_no_plugins(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        result = invoke(["plugins", "validate"])
 
-    def get_command(self):
-        @click.command(help="Test command")
-        def testcmd():
-            click.echo("Hello from test plugin!")
-        return testcmd
-"""
-            (plugins_dir / "test_plugin.py").write_text(plugin_content)
+        assert result.exit_code == 0
+        assert "No plugins found" in result.output
 
-            with patch("xsoar_cli.plugins.manager.PluginManager") as mock_manager_class:
-                mock_manager = PluginManager(plugins_dir=plugins_dir)
-                mock_manager_class.return_value = mock_manager
+    def test_validate_all_valid(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin = MagicMock()
+        mock_command = click.Command("test", callback=lambda: None)
+        mock_plugin.get_command.return_value = mock_command
 
-                result = invoke(["--help"])
-                assert result.exit_code == 0
+        mock_plugin_env.manager.loaded_plugins["test_plugin"] = mock_plugin
+
+        result = invoke(["plugins", "validate"])
+
+        assert result.exit_code == 0
+        assert "test_plugin: Valid" in result.output
+        assert "All plugins are valid!" in result.output
+
+    def test_validate_with_failed_plugins(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin_env.manager.get_failed_plugins.return_value = {
+            "broken": "SyntaxError: invalid syntax",
+        }
+
+        result = invoke(["plugins", "validate"])
+
+        assert result.exit_code == 0
+        assert "broken: SyntaxError" in result.output
+        assert "Some plugins have validation errors." in result.output
+
+    def test_validate_with_conflicts(self, invoke: InvokeHelper, mock_plugin_env) -> None:
+        mock_plugin = MagicMock()
+        mock_plugin.get_command.return_value = click.Command("test", callback=lambda: None)
+        mock_plugin_env.manager.loaded_plugins["test_plugin"] = mock_plugin
+        mock_plugin_env.manager.get_command_conflicts.return_value = [
+            {"plugin_name": "test_plugin", "command_name": "case", "plugin_version": "1.0.0"},
+        ]
+
+        result = invoke(["plugins", "validate"])
+
+        assert result.exit_code == 0
+        assert "Command Conflicts Detected" in result.output
+        assert "Some plugins have validation errors." in result.output

--- a/tests/unit/test_plugin_manager.py
+++ b/tests/unit/test_plugin_manager.py
@@ -1,5 +1,8 @@
-import tempfile
+from __future__ import annotations
+
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import click
 import pytest
@@ -8,51 +11,69 @@ from xsoar_cli.plugins.manager import PluginManager
 
 
 class TestPluginManager:
-    def test_plugin_manager_initialization(self):
+    def test_plugin_manager_initialization(self, tmp_path: Path):
         """Test that plugin manager initializes correctly."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            plugins_dir = Path(temp_dir) / "plugins"
-            manager = PluginManager(plugins_dir=plugins_dir)
+        plugins_dir = tmp_path / "plugins"
+        manager = PluginManager(plugins_dir=plugins_dir)
 
-            assert manager.plugins_dir == plugins_dir
-            assert plugins_dir.exists()
-            assert manager.loaded_plugins == {}
-            assert manager.failed_plugins == {}
+        assert manager.plugins_dir == plugins_dir
+        assert not plugins_dir.exists()
+        assert manager.loaded_plugins == {}
+        assert manager.failed_plugins == {}
 
-    def test_discover_plugins_empty_directory(self):
+    def test_plugins_dir_exists_false(self, tmp_path: Path):
+        """Test plugins_dir_exists returns False for non-existent directory."""
+        plugins_dir = tmp_path / "plugins"
+        manager = PluginManager(plugins_dir=plugins_dir)
+
+        assert manager.plugins_dir_exists is False
+
+    def test_plugins_dir_exists_true(self, tmp_path: Path):
+        """Test plugins_dir_exists returns True for existing directory."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        manager = PluginManager(plugins_dir=plugins_dir)
+
+        assert manager.plugins_dir_exists is True
+
+    def test_discover_plugins_missing_directory(self, tmp_path: Path):
+        """Test that discover_plugins returns empty list when directory does not exist."""
+        plugins_dir = tmp_path / "plugins"
+        manager = PluginManager(plugins_dir=plugins_dir)
+
+        discovered = manager.discover_plugins()
+        assert discovered == []
+
+    def test_discover_plugins_empty_directory(self, tmp_path: Path):
         """Test plugin discovery in empty directory."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            plugins_dir = Path(temp_dir) / "plugins"
-            manager = PluginManager(plugins_dir=plugins_dir)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        manager = PluginManager(plugins_dir=plugins_dir)
 
-            discovered = manager.discover_plugins()
-            assert discovered == []
+        discovered = manager.discover_plugins()
+        assert discovered == []
 
-    def test_discover_plugins_with_files(self):
+    def test_discover_plugins_with_files(self, tmp_path: Path):
         """Test plugin discovery with Python files."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            plugins_dir = Path(temp_dir) / "plugins"
-            plugins_dir.mkdir()
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
 
-            # Create test files
-            (plugins_dir / "plugin1.py").write_text("# plugin 1")
-            (plugins_dir / "plugin2.py").write_text("# plugin 2")
-            (plugins_dir / "__init__.py").write_text("# should be ignored")
-            (plugins_dir / "not_python.txt").write_text("# not python")
+        (plugins_dir / "plugin1.py").write_text("# plugin 1")
+        (plugins_dir / "plugin2.py").write_text("# plugin 2")
+        (plugins_dir / "__init__.py").write_text("# should be ignored")
+        (plugins_dir / "not_python.txt").write_text("# not python")
 
-            manager = PluginManager(plugins_dir=plugins_dir)
-            discovered = manager.discover_plugins()
+        manager = PluginManager(plugins_dir=plugins_dir)
+        discovered = manager.discover_plugins()
 
-            assert sorted(discovered) == ["plugin1", "plugin2"]
+        assert sorted(discovered) == ["plugin1", "plugin2"]
 
-    def test_load_valid_plugin(self):
+    def test_load_valid_plugin(self, tmp_path: Path):
         """Test loading a valid plugin."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            plugins_dir = Path(temp_dir) / "plugins"
-            plugins_dir.mkdir()
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
 
-            # Create a valid plugin file
-            plugin_content = """
+        plugin_content = """
 import click
 from xsoar_cli.plugins import XSOARPlugin
 
@@ -75,62 +96,56 @@ class TestPlugin(XSOARPlugin):
             click.echo("test")
         return test_cmd
 """
-            (plugins_dir / "test_plugin.py").write_text(plugin_content)
+        (plugins_dir / "test_plugin.py").write_text(plugin_content)
 
-            manager = PluginManager(plugins_dir=plugins_dir)
-            plugin = manager.load_plugin("test_plugin")
+        manager = PluginManager(plugins_dir=plugins_dir)
+        plugin = manager.load_plugin("test_plugin")
 
-            assert plugin is not None
-            assert plugin.name == "test"
-            assert plugin.version == "1.0.0"
-            assert plugin.description == "Test plugin"
-            assert "test_plugin" in manager.loaded_plugins
+        assert plugin is not None
+        assert plugin.name == "test"
+        assert plugin.version == "1.0.0"
+        assert plugin.description == "Test plugin"
+        assert "test_plugin" in manager.loaded_plugins
 
-    def test_load_invalid_plugin(self):
+    def test_load_invalid_plugin(self, tmp_path: Path):
         """Test loading an invalid plugin."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            plugins_dir = Path(temp_dir) / "plugins"
-            plugins_dir.mkdir()
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
 
-            # Create an invalid plugin file (syntax error)
-            plugin_content = """
+        plugin_content = """
 invalid python syntax !!!
 """
-            (plugins_dir / "invalid_plugin.py").write_text(plugin_content)
+        (plugins_dir / "invalid_plugin.py").write_text(plugin_content)
 
-            manager = PluginManager(plugins_dir=plugins_dir)
+        manager = PluginManager(plugins_dir=plugins_dir)
 
-            with pytest.raises(Exception):
-                manager.load_plugin("invalid_plugin")
+        with pytest.raises(Exception):
+            manager.load_plugin("invalid_plugin")
 
-    def test_load_plugin_no_plugin_class(self):
+    def test_load_plugin_no_plugin_class(self, tmp_path: Path):
         """Test loading a file with no plugin class."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            plugins_dir = Path(temp_dir) / "plugins"
-            plugins_dir.mkdir()
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
 
-            # Create a file with no plugin class
-            plugin_content = """
+        plugin_content = """
 import click
 
 def some_function():
     pass
 """
-            (plugins_dir / "no_plugin.py").write_text(plugin_content)
+        (plugins_dir / "no_plugin.py").write_text(plugin_content)
 
-            manager = PluginManager(plugins_dir=plugins_dir)
+        manager = PluginManager(plugins_dir=plugins_dir)
 
-            with pytest.raises(Exception):
-                manager.load_plugin("no_plugin")
+        with pytest.raises(Exception):
+            manager.load_plugin("no_plugin")
 
-    def test_load_all_plugins(self):
+    def test_load_all_plugins(self, tmp_path: Path):
         """Test loading all plugins with mixed valid/invalid."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            plugins_dir = Path(temp_dir) / "plugins"
-            plugins_dir.mkdir()
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
 
-            # Valid plugin
-            valid_plugin = """
+        valid_plugin = """
 import click
 from xsoar_cli.plugins import XSOARPlugin
 
@@ -149,29 +164,121 @@ class ValidPlugin(XSOARPlugin):
             pass
         return valid_cmd
 """
-            (plugins_dir / "valid_plugin.py").write_text(valid_plugin)
+        (plugins_dir / "valid_plugin.py").write_text(valid_plugin)
+        (plugins_dir / "invalid_plugin.py").write_text("invalid syntax !!!")
 
-            # Invalid plugin
-            (plugins_dir / "invalid_plugin.py").write_text("invalid syntax !!!")
+        manager = PluginManager(plugins_dir=plugins_dir)
+        loaded = manager.load_all_plugins(ignore_errors=True)
 
-            manager = PluginManager(plugins_dir=plugins_dir)
-            loaded = manager.load_all_plugins(ignore_errors=True)
+        assert len(loaded) == 1
+        assert "valid_plugin" in loaded
+        assert len(manager.failed_plugins) == 1
+        assert "invalid_plugin" in manager.failed_plugins
 
-            assert len(loaded) == 1
-            assert "valid_plugin" in loaded
-            assert len(manager.failed_plugins) == 1
-            assert "invalid_plugin" in manager.failed_plugins
+    def test_register_continues_past_failure(self, tmp_path: Path):
+        """Test that register_plugin_commands continues after one plugin fails."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        plugin_a_content = """
+import click
+from xsoar_cli.plugins import XSOARPlugin
+
+class PluginA(XSOARPlugin):
+    @property
+    def name(self):
+        return "plugin_a"
+
+    @property
+    def version(self):
+        return "1.0.0"
+
+    def get_command(self):
+        @click.command()
+        def cmd_a():
+            click.echo("a")
+        return cmd_a
+"""
+        plugin_b_content = """
+import click
+from xsoar_cli.plugins import XSOARPlugin
+
+class PluginB(XSOARPlugin):
+    @property
+    def name(self):
+        return "plugin_b"
+
+    @property
+    def version(self):
+        return "1.0.0"
+
+    def get_command(self):
+        @click.command()
+        def cmd_b():
+            click.echo("b")
+        return cmd_b
+"""
+        (plugins_dir / "plugin_a.py").write_text(plugin_a_content)
+        (plugins_dir / "plugin_b.py").write_text(plugin_b_content)
+
+        manager = PluginManager(plugins_dir=plugins_dir)
+        manager.load_all_plugins(ignore_errors=True)
+
+        assert "plugin_a" in manager.loaded_plugins
+        assert "plugin_b" in manager.loaded_plugins
+
+        # Mock get_command on the first plugin to raise an exception.
+        plugin_a_instance = manager.loaded_plugins["plugin_a"]
+        with patch.object(plugin_a_instance, "get_command", side_effect=RuntimeError("boom")):
+            mock_cli = click.Group()
+            manager.register_plugin_commands(mock_cli)
+
+        # plugin_b's command should have been registered despite plugin_a's failure.
+        # Click converts underscores to hyphens in command names by default.
+        assert "cmd-b" in mock_cli.commands
+        assert "plugin_a" in manager.failed_plugins
+
+    def test_sys_modules_not_polluted(self, tmp_path: Path):
+        """Test that loading a plugin does not leave bare module names in sys.modules."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        plugin_content = """
+import click
+from xsoar_cli.plugins import XSOARPlugin
+
+class CleanPlugin(XSOARPlugin):
+    @property
+    def name(self):
+        return "clean"
+
+    @property
+    def version(self):
+        return "1.0.0"
+
+    def get_command(self):
+        @click.command()
+        def clean_cmd():
+            click.echo("clean")
+        return clean_cmd
+"""
+        (plugins_dir / "test_plugin.py").write_text(plugin_content)
+
+        manager = PluginManager(plugins_dir=plugins_dir)
+        manager.load_plugin("test_plugin")
+
+        assert "test_plugin" not in sys.modules
 
 
 class TestPluginConflicts:
-    def test_command_conflict_detection(self):
+    def test_command_conflict_detection(self, tmp_path: Path):
         """Test that command conflicts are detected and handled properly."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            plugins_dir = Path(temp_dir) / "plugins"
-            plugins_dir.mkdir()
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
 
-            # Create a plugin that conflicts with a core command
-            conflict_plugin = """import click
+        conflict_plugin = """
+import click
+from xsoar_cli.plugins import XSOARPlugin
 
 class ConflictPlugin(XSOARPlugin):
     @property
@@ -184,30 +291,29 @@ class ConflictPlugin(XSOARPlugin):
 
     def get_command(self):
         @click.command()
-        def case():  # This conflicts with core 'case' command
+        def case():
             click.echo("conflict")
         return case
 """
-            (plugins_dir / "conflict_plugin.py").write_text(conflict_plugin)
+        (plugins_dir / "conflict_plugin.py").write_text(conflict_plugin)
 
-            manager = PluginManager(plugins_dir=plugins_dir)
-            manager.load_all_plugins(ignore_errors=True)
+        manager = PluginManager(plugins_dir=plugins_dir)
+        manager.load_all_plugins(ignore_errors=True)
 
-            # Create a mock CLI group with core commands
-            mock_cli = click.Group()
-            mock_cli.add_command(click.Command("case", callback=lambda: None))
-            mock_cli.add_command(click.Command("config", callback=lambda: None))
+        # Create a mock CLI group with core commands
+        mock_cli = click.Group()
+        mock_cli.add_command(click.Command("case", callback=lambda: None))
+        mock_cli.add_command(click.Command("config", callback=lambda: None))
 
-            # Register plugin commands
-            manager.register_plugin_commands(mock_cli)
+        # Register plugin commands
+        manager.register_plugin_commands(mock_cli)
 
-            # Check that conflicts were detected
-            conflicts = manager.get_command_conflicts()
-            assert len(conflicts) == 1
-            assert conflicts[0]["plugin_name"] == "conflict_plugin"
-            assert conflicts[0]["command_name"] == "case"
-            assert conflicts[0]["plugin_version"] == "1.0.0"
+        # Check that conflicts were detected
+        conflicts = manager.get_command_conflicts()
+        assert len(conflicts) == 1
+        assert conflicts[0]["plugin_name"] == "conflict_plugin"
+        assert conflicts[0]["command_name"] == "case"
+        assert conflicts[0]["plugin_version"] == "1.0.0"
 
-            # Verify that the conflicting command was NOT registered
-            assert "case" in mock_cli.commands  # Core command should still be there
-            # The plugin command should not have overwritten the core command
+        # Core command should still be there (plugin command should not overwrite it)
+        assert "case" in mock_cli.commands


### PR DESCRIPTION
Refactor the plugin system to align with project conventions and design patterns, as detailed in `PLUGIN_REFACTOR.md`.

## Summary of changes

### Step 1: `plugins/__init__.py`
- Replace `Optional[str]` with `str | None`
- Trim docstrings to match project style

### Step 2: `plugins/manager.py`
- Remove `mkdir` from constructor (directory creation moves to `plugins init`)
- Remove `sys.path` manipulation (not needed with `spec_from_file_location`)
- Remove `XSOARPlugin` magic injection into plugin modules
- Remove `sys.modules` registration of plugin modules
- Add `NameError` catch with migration guidance message for plugins missing the import
- Add `DEFAULT_PLUGINS_DIR` class attribute and `plugins_dir_exists` property
- Fix logging levels (routine ops to debug, failures to warning)
- Change `register_plugin_commands` to skip-and-record on failure instead of raising

### Step 3: `commands/plugins/commands.py`
- Add `plugins init` command (creates directory, writes example plugin)
- Refactor `list`, `info`, `validate` to use module-level `plugin_manager` from `cli.py`
- Add `plugins_dir_exists` guard with clear error message on all commands
- Fix `info` command path interpolation bug

### Step 4: `cli.py`
- Simplify `_load_plugins`: early return when directory missing, remove outer try/except

### Step 5: Tests
- Add `mock_plugin_env` composite fixture
- Rewrite CLI tests to use the fixture (19 tests covering init, list, info, validate)
- Refactor unit tests: `tmp_path`, new tests for `plugins_dir_exists`, `discover_plugins` with missing dir, skip-and-record registration, `sys.modules` not polluted

### Step 6: Documentation
- Update plugin README: init step, explicit import, limitations section
- Update commands README: init subcommand docs
- Update CHANGELOG

## Breaking changes

Plugins must now explicitly import `XSOARPlugin`:
```python
from xsoar_cli.plugins import XSOARPlugin
```
Plugins that rely on the old implicit injection will fail with a clear error message directing the author to add the import.

## Test results

All 407 tests pass.