### PR TITLE
Replace --details/--verbose with --detail-level option in content list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `content list` now uses a single `--detail-level` option (choices: `short`, `extended`, `full`, default: `short`) instead of the separate `--details` and `--verbose` flags.
+
+### Removed
+
+- `content list --details` flag. Use `--detail-level extended` instead.
+- `content list --verbose` flag. Use `--detail-level full` instead.
+
 ## [2.2.0] - 2026-04-10
 
 ### Added

--- a/src/xsoar_cli/commands/content/README.md
+++ b/src/xsoar_cli/commands/content/README.md
@@ -29,12 +29,14 @@ List available content items. Enumerates commands, playbooks and scripts availab
 **Options:**
 - `--environment TEXT` - Target environment (default: uses default environment from config)
 - `--type [scripts|playbooks|commands|all]` - Type of content items to list (default: all)
+- `--detail-level [short|extended|full]` - Amount of detail in the output (default: short)
 
 **Examples:**
 ```
 xsoar-cli content list
 xsoar-cli content list --environment prod
 xsoar-cli content list --type commands
+xsoar-cli content list --type commands --detail-level extended
 xsoar-cli content list --type playbooks --environment dev
 ```
 

--- a/src/xsoar_cli/commands/content/commands.py
+++ b/src/xsoar_cli/commands/content/commands.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import click
 
 from xsoar_cli.utilities.config_file import get_xsoar_config, load_config
-from xsoar_cli.utilities.content import filter_content
+from xsoar_cli.utilities.content import DETAIL_LEVELS, filter_content
 from xsoar_cli.utilities.download_content_handlers import HANDLERS, resolve_output_path
 from xsoar_cli.utilities.validators import validate_xsoar_connectivity
 
@@ -55,19 +55,25 @@ def get_detached(ctx: click.Context, environment: str | None, content_type: str)
     show_default=True,
     help="Type of content items to list.",
 )
-@click.option("--detail", is_flag=True, default=False, help="Include argument-level detail in filtered output.")
-@click.option("--verbose", is_flag=True, default=False, help="Output the full unfiltered response.")
+@click.option(
+    "--detail-level",
+    type=click.Choice(DETAIL_LEVELS, case_sensitive=False),
+    default="short",
+    show_default=True,
+    help="Amount of detail to include in the output.",
+)
 @click.pass_context
 @load_config
 @validate_xsoar_connectivity
-def list_content(ctx: click.Context, environment: str | None, content_type: str, detail: bool, verbose: bool) -> None:
+def list_content(ctx: click.Context, environment: str | None, content_type: str, detail_level: str) -> None:
     """
-    List detached content items. The purpose of this function is to list out available commands,
-    playbooks and scripts, primarily to facilitate better AI generated playbooks"""
+    List available content items. Enumerates commands, playbooks and scripts
+    available on the server, primarily to facilitate better AI generated
+    playbooks."""
     config = get_xsoar_config(ctx)
     xsoar_client: Client = config.get_client(environment)
     json_blob = xsoar_client.content.list(content_type)
-    if verbose:
+    if detail_level == "full":
         click.echo(json.dumps(json_blob, indent=4))
         ctx.exit(0)
 
@@ -75,7 +81,7 @@ def list_content(ctx: click.Context, environment: str | None, content_type: str,
     if isinstance(json_blob, list):
         json_blob = {content_type: json_blob}
 
-    filtered = filter_content(json_blob, detail=detail)
+    filtered = filter_content(json_blob, detail_level=detail_level)
     click.echo(json.dumps(filtered, indent=4))
 
 

--- a/src/xsoar_cli/utilities/content.py
+++ b/src/xsoar_cli/utilities/content.py
@@ -5,13 +5,15 @@ than downstream consumers (especially LLM-based tooling) need. The functions
 in this module strip each content type down to the fields that matter while
 keeping the output structure extensible.
 
-Two levels of filtering are available:
+Three detail levels are available:
 
-- **Summary** (default): compact id/name representation per item. Designed for
+- **short** (default): compact id/name representation per item. Designed for
   discovery, where an LLM scans the full list to identify relevant items.
-- **Detail** (``--detail``): includes inputs, outputs, and arguments reduced
-  to the fields that matter. Intended for retrieving actionable detail on a
-  smaller set of items.
+- **extended**: includes inputs, outputs, and arguments reduced to the fields
+  that matter. Intended for retrieving actionable detail on a smaller set of
+  items.
+- **full**: the raw, unfiltered API response. Handled by the CLI command
+  before calling into this module.
 """
 
 from __future__ import annotations
@@ -57,9 +59,6 @@ def filter_scripts(scripts: list[dict]) -> list[dict]:
     return filtered
 
 
-# -- Playbooks ---------------------------------------------------------------
-
-
 def summarize_playbooks(playbooks: list[dict]) -> list[dict]:
     """Return an id + name summary for each playbook.
 
@@ -101,9 +100,6 @@ def filter_playbooks(playbooks: list[dict]) -> list[dict]:
         )
 
     return filtered
-
-
-# -- Commands ----------------------------------------------------------------
 
 
 def _group_commands_by_brand(instances: list[dict]) -> list[dict]:
@@ -174,35 +170,39 @@ def filter_commands(instances: list[dict]) -> list[dict]:
     return filtered
 
 
-# -- Dispatch ----------------------------------------------------------------
+DETAIL_LEVELS = ("short", "extended", "full")
 
 
-def filter_content(raw: dict, *, detail: bool = False) -> dict:
+def filter_content(raw: dict, *, detail_level: str = "short") -> dict:
     """Dispatch filtering for each content type present in *raw*.
 
     ``raw`` is the dict returned by ``xsoar_client.content.list()`` and may
     contain any combination of ``scripts``, ``playbooks``, and ``commands``
     keys depending on the requested type.
 
-    When *detail* is ``True``, the output includes argument/input/output-level
-    information. When ``False`` (the default), only identifying fields are kept.
+    *detail_level* controls how much information is kept:
+
+    - ``"short"``: compact id/name summary only.
+    - ``"extended"``: includes arguments, inputs, and outputs.
+    - ``"full"``: not handled here (the caller should output the raw response
+      directly).
     """
     result: dict = {}
 
     if "scripts" in raw:
-        if detail:
+        if detail_level == "extended":
             result["scripts"] = filter_scripts(raw["scripts"])
         else:
             result["scripts"] = summarize_scripts(raw["scripts"])
 
     if "playbooks" in raw:
-        if detail:
+        if detail_level == "extended":
             result["playbooks"] = filter_playbooks(raw["playbooks"])
         else:
             result["playbooks"] = summarize_playbooks(raw["playbooks"])
 
     if "commands" in raw:
-        if detail:
+        if detail_level == "extended":
             result["commands"] = filter_commands(raw["commands"])
         else:
             result["commands"] = summarize_commands(raw["commands"])

--- a/tests/unit/test_content_filters.py
+++ b/tests/unit/test_content_filters.py
@@ -315,7 +315,7 @@ class TestFilterCommands:
 class TestFilterContent:
     def test_scripts_summary(self) -> None:
         raw = {"scripts": _SCRIPTS}
-        result = filter_content(raw, detail=False)
+        result = filter_content(raw, detail_level="short")
         assert "scripts" in result
         assert len(result["scripts"]) == 3
         assert result["scripts"][0] == {
@@ -325,13 +325,13 @@ class TestFilterContent:
 
     def test_scripts_detail(self) -> None:
         raw = {"scripts": _SCRIPTS}
-        result = filter_content(raw, detail=True)
+        result = filter_content(raw, detail_level="extended")
         assert "scripts" in result
         assert "arguments" in result["scripts"][0]
 
     def test_playbooks_summary(self) -> None:
         raw = {"playbooks": _PLAYBOOKS}
-        result = filter_content(raw, detail=False)
+        result = filter_content(raw, detail_level="short")
         assert "playbooks" in result
         assert result["playbooks"][0] == {
             "id": "22a1b2c3-d4e5-6f78-9a0b-c1d2e3f4a5b6",
@@ -340,20 +340,20 @@ class TestFilterContent:
 
     def test_playbooks_detail(self) -> None:
         raw = {"playbooks": _PLAYBOOKS}
-        result = filter_content(raw, detail=True)
+        result = filter_content(raw, detail_level="extended")
         assert "playbooks" in result
         assert "inputs" in result["playbooks"][0]
         assert "outputs" in result["playbooks"][0]
 
     def test_commands_summary(self) -> None:
         raw = {"commands": _COMMAND_INSTANCES}
-        result = filter_content(raw, detail=False)
+        result = filter_content(raw, detail_level="short")
         assert "commands" in result
         assert len(result["commands"]) == 2
 
     def test_commands_detail(self) -> None:
         raw = {"commands": _COMMAND_INSTANCES}
-        result = filter_content(raw, detail=True)
+        result = filter_content(raw, detail_level="extended")
         assert "commands" in result
         assert "arguments" in result["commands"][0]["commands"][0]
 
@@ -363,7 +363,7 @@ class TestFilterContent:
             "playbooks": _PLAYBOOKS,
             "commands": _COMMAND_INSTANCES,
         }
-        result = filter_content(raw, detail=False)
+        result = filter_content(raw, detail_level="short")
         assert set(result.keys()) == {"scripts", "playbooks", "commands"}
 
     def test_empty_dict(self) -> None:


### PR DESCRIPTION
## Summary

Consolidates the two boolean flags (`--details` and `--verbose`) on `content list` into a single `--detail-level` choice option with three levels:

- `short` (default): compact id/name summary per item
- `extended`: includes arguments, inputs, and outputs (previously `--details`)
- `full`: raw unfiltered API response (previously `--verbose`)

## Changes

- **`src/xsoar_cli/utilities/content.py`**: `filter_content()` now accepts `detail_level: str` instead of `details: bool`. Added `DETAIL_LEVELS` constant.
- **`src/xsoar_cli/commands/content/commands.py`**: Replaced the two flags with a single `--detail-level` Click choice option. Fixed the docstring which incorrectly described the command as listing detached items.
- **`tests/unit/test_content_filters.py`**: Updated all `filter_content()` calls to use the new `detail_level` keyword. This also fixes a pre-existing bug where tests passed `detail=` instead of the correct parameter name `details=`.
- **`CHANGELOG.md`** and **`src/xsoar_cli/commands/content/README.md`**: Documented the change.

## Migration

| Before | After |
|---|---|
| `content list` | `content list` (unchanged) |
| `content list --details` | `content list --detail-level extended` |
| `content list --verbose` | `content list --detail-level full` |