### PR TITLE
Separate plugin commands from core commands in --help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **Breaking:** `content list` now uses a single `--detail-level` option (choices: `short`, `extended`, `full`, default: `short`) instead of the separate `--details` and `--verbose` flags.
+- Plugin commands are now listed under a separate `Plugins:` section in `--help` output instead of being mixed with core commands.
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,9 +206,11 @@ The user's live configuration at `~/.config/xsoar-cli/config.json` contains API 
 
 ## Changelog
 
+**Every PR that changes user-facing behavior MUST include a `CHANGELOG.md` update. Do not treat this as optional or as a follow-up step. The changelog entry is part of the implementation, not separate from it.**
+
 - The project maintains a `CHANGELOG.md` in the repository root.
 - The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-- All user-facing changes must be documented in `CHANGELOG.md`. This includes:
+- Changes that require a changelog entry:
   - Adding, removing, or renaming commands, options, or arguments (`Added` / `Removed`)
   - Changes to default behavior or output format (`Changed`)
   - Bug fixes (`Fixed`)

--- a/src/xsoar_cli/cli.py
+++ b/src/xsoar_cli/cli.py
@@ -163,6 +163,7 @@ def _configure_logging(config_data: dict | None) -> LoggingSetup:
 # "Exit:" entries for pytest invocations.
 _register_commands()
 CORE_COMMANDS, plugin_manager = _load_plugins()
+cli.core_commands = set(CORE_COMMANDS)
 
 # Initialized in main(). None when the module is imported without calling main(),
 # which is the case during test runs.

--- a/src/xsoar_cli/cli.py
+++ b/src/xsoar_cli/cli.py
@@ -30,11 +30,45 @@ from .utilities.version_check import check_for_update
 
 
 class XSOARCliGroup(click.Group):
-    """Custom Click group that surfaces plugin load failures when a command is not found.
+    """Custom Click group with separate help sections for core and plugin commands.
 
-    Without this, a failed plugin silently disappears and the user gets a generic
-    "No such command" error with no indication that a plugin was involved.
+    Also surfaces plugin load failures when a command is not found, so the user
+    does not get a generic "No such command" error with no indication that a
+    plugin was involved.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.core_commands: set[str] = set()
+
+    def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        """Format help output with core commands and plugin commands in separate sections."""
+        core_rows = []
+        plugin_rows = []
+
+        for subcommand in self.list_commands(ctx):
+            cmd = self.get_command(ctx, subcommand)
+            if cmd is None or cmd.hidden:
+                continue
+            target = core_rows if subcommand in self.core_commands else plugin_rows
+            target.append((subcommand, cmd))
+
+        if not core_rows and not plugin_rows:
+            return
+
+        all_names = core_rows + plugin_rows
+        limit = formatter.width - 6 - max(len(name) for name, _ in all_names)
+
+        def make_rows(commands):
+            return [(name, cmd.get_short_help_str(limit)) for name, cmd in commands]
+
+        if core_rows:
+            with formatter.section("Commands"):
+                formatter.write_dl(make_rows(core_rows))
+
+        if plugin_rows:
+            with formatter.section("Plugins"):
+                formatter.write_dl(make_rows(plugin_rows))
 
     def resolve_command(self, ctx: click.Context, args: list) -> tuple:
         try:

--- a/tests/cli/test_base.py
+++ b/tests/cli/test_base.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import click
 import pytest
+
+from xsoar_cli.cli import cli
 
 
 class TestBase:
@@ -15,3 +18,54 @@ class TestBase:
     def test_base_commands(self, invoke, cli_args: list[str], expected_exit_code: int) -> None:
         result = invoke(cli_args)
         assert result.exit_code == expected_exit_code
+
+
+class TestHelpSections:
+    """Verify that --help separates core commands from plugin commands."""
+
+    def test_help_shows_commands_section(self, invoke) -> None:
+        result = invoke(["--help"])
+        assert "Commands:" in result.output
+
+    def test_help_hides_plugins_section_when_no_plugins(self, invoke) -> None:
+        plugin_cmds = {name: cmd for name, cmd in cli.commands.items() if name not in cli.core_commands}
+        for name in plugin_cmds:
+            cli.commands.pop(name)
+        try:
+            result = invoke(["--help"])
+            assert "Plugins:" not in result.output
+        finally:
+            cli.commands.update(plugin_cmds)
+
+    def test_help_shows_plugins_section_for_plugin_commands(self, invoke) -> None:
+        @click.command()
+        def fake_plugin():
+            """A fake plugin command."""
+
+        cli.add_command(fake_plugin)
+        try:
+            result = invoke(["--help"])
+            assert "Plugins:" in result.output
+            assert "fake-plugin" in result.output
+            # Core commands should still be under "Commands:"
+            assert "Commands:" in result.output
+        finally:
+            cli.commands.pop("fake-plugin", None)
+
+    def test_core_commands_not_listed_under_plugins(self, invoke) -> None:
+        @click.command()
+        def fake_plugin():
+            """A fake plugin command."""
+
+        cli.add_command(fake_plugin)
+        try:
+            result = invoke(["--help"])
+            # Split output into sections and verify core commands are not in the Plugins section
+            parts = result.output.split("Plugins:")
+            assert len(parts) == 2
+            plugins_section = parts[1]
+            assert "config" not in plugins_section
+            assert "pack" not in plugins_section
+            assert "fake-plugin" in plugins_section
+        finally:
+            cli.commands.pop("fake-plugin", None)


### PR DESCRIPTION
## Summary

Plugin commands are now listed under a separate `Plugins:` section in `--help` output, making it easy to distinguish them from core commands.

### Before

```
Commands:
  case         Create, retrieve, and clone cases
  completions  Install and manage shell completion for xsoar-cli
  config       Create, validate, and manage CLI configuration
  content      Inspect and manage content items
  graph        (BETA) Create dependency graphs from one or more content...
  hello        Say hello.
  integration  (BETA) Save/load integration configuration for an...
  manifest     Various commands to interact/update/deploy content packs...
  pack         Various content pack related commands.
  plugins      Manage XSOAR CLI plugins.
  rbac         Dump roles, users and user groups
```

### After

```
Commands:
  case         Create, retrieve, and clone cases
  completions  Install and manage shell completion for xsoar-cli
  config       Create, validate, and manage CLI configuration
  content      Inspect and manage content items
  graph        (BETA) Create dependency graphs from one or more content...
  integration  (BETA) Save/load integration configuration for an...
  manifest     Various commands to interact/update/deploy content packs...
  pack         Various content pack related commands.
  plugins      Manage XSOAR CLI plugins.
  rbac         Dump roles, users and user groups

Plugins:
  hello        Say hello.
```

The `Plugins:` section only appears when plugin commands are loaded.

## Changes

1. **`XSOARCliGroup`**: Added `core_commands` set attribute and `format_commands` override that splits commands into two sections.
2. **Module-level init**: Populate `cli.core_commands` after commands and plugins are loaded.
3. **Tests**: Added `TestHelpSections` class in `test_base.py` covering both with and without plugins.