### PR TITLE
fix: print pack diff details in manifest validate --mode diff

### DIFF
--- a/src/xsoar_cli/commands/manifest/commands.py
+++ b/src/xsoar_cli/commands/manifest/commands.py
@@ -303,6 +303,14 @@ def validate(ctx: click.Context, environment: str | None, mode: str, manifest: s
             if not packs_to_check:
                 click.echo("- no diff from installed versions found in manifest.")
             else:
+                click.echo()
+                for pack in packs_to_check:
+                    installed = installed_by_id.get(pack["id"])
+                    if not installed:
+                        click.echo(f"  + {pack['id']} {pack['version']} (new)")
+                    else:
+                        click.echo(f"  ~ {pack['id']} {installed['currentVersion']} -> {pack['version']}")
+                click.echo(f"  Validating {key} reachability ", nl=False)
                 _check_pack_availability(
                     xsoar_client,
                     packs_to_check,


### PR DESCRIPTION
Previously, `manifest validate --mode diff` only printed dots when custom or marketplace packs had version differences, giving no indication of which packs differed or what changed. This made the output indistinguishable from a successful no-op unless you counted the dots.

Now the command prints each differing pack with its version change (or marks it as new) before validating reachability, e.g.:

  Checking custom_packs availability
    ~ MyOrg_EDR 1.0.0 -> 2.0.0
    + MyOrg_NewPack 1.0.0 (new) Validating custom_packs reachability ..