### PR TITLE
Fix a bug where playbook name with spaces did not show up in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `content download` now correctly resolves playbooks whose ID differs from their name when the name contains spaces. Previously, the name search query was not quoted, causing it to return no results. In practice this affected custom playbooks created in the XSOAR UI, which use a UUID as their ID.
+
 ### Changed
 
 - **Breaking:** `content list` now uses a single `--detail-level` option (choices: `short`, `extended`, `full`, default: `short`) instead of the separate `--details` and `--verbose` flags.

--- a/src/xsoar_cli/xsoar_client/content.py
+++ b/src/xsoar_cli/xsoar_client/content.py
@@ -81,7 +81,7 @@ class Content:
         can differ from the display name (e.g., UUIDs for custom playbooks).
         """
         endpoint = "/playbook/search"
-        payload = {"query": f"name:{name}"}
+        payload = {"query": f'name:"{name}"'}
         response = self.client.make_request(endpoint=endpoint, method="POST", json=payload)
         response.raise_for_status()
         playbooks = response.json().get("playbooks") or []


### PR DESCRIPTION
Custom playbooks (created from the XSOAR UI) are given a UUID style internal ID, which means that name and ID does not match. When attempting to download such a playbook with
`xsoar-cli content download --type playbook "My Awesome Playbook"` the name->ID translation would fail because it would search for the playbook _without_ quotes.