### PR TITLE
Refactor manifest validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Breaking:** `manifest validate` now validates all packs by default (previously defaulted to `--mode diff`). Use the new `--only-changed` flag to validate only packs that differ from what is installed on the server.
 - **Breaking:** `content list` now uses a single `--detail-level` option (choices: `short`, `extended`, `full`, default: `short`) instead of the separate `--details` and `--verbose` flags.
 - Plugin commands are now listed under a separate `Plugins:` section in `--help` output instead of being mixed with core commands.
 
 ### Removed
 
+- `manifest validate --mode` option. Use `--only-changed` instead of `--mode diff`. Full validation is now the default.
 - `content list --details` flag. Use `--detail-level extended` instead.
 - `content list --verbose` flag. Use `--detail-level full` instead.
 

--- a/src/xsoar_cli/commands/manifest/README.md
+++ b/src/xsoar_cli/commands/manifest/README.md
@@ -23,11 +23,13 @@ xsoar-cli manifest generate --environment prod
 
 Validate manifest JSON syntax and verify all specified content packs are available. Tests connectivity to pack sources and checks local pack metadata for development packs.
 
+By default, all packs in the manifest are validated. Use `--only-changed` to limit validation to packs whose version differs from what is currently installed on the server. This is useful in CI pipelines where only a few packs change per PR.
+
 **Syntax:** `xsoar-cli manifest validate [OPTIONS] MANIFEST_PATH`
 
 **Options:**
 - `--environment TEXT` - Target environment (default: uses default environment from config)
-- `--mode [full|diff]` - Validate the full manifest, or only the definitions that diff with installed versions (default: diff)
+- `--only-changed` - Only validate packs that differ from what is currently installed on the server
 
 **Arguments:**
 - `MANIFEST_PATH` - Path to the manifest file to validate
@@ -35,6 +37,7 @@ Validate manifest JSON syntax and verify all specified content packs are availab
 **Examples:**
 ```
 xsoar-cli manifest validate ./xsoar_config.json
+xsoar-cli manifest validate --only-changed ./xsoar_config.json
 xsoar-cli manifest validate --environment staging ./xsoar_config.json
 ```
 

--- a/src/xsoar_cli/commands/manifest/commands.py
+++ b/src/xsoar_cli/commands/manifest/commands.py
@@ -248,23 +248,33 @@ def update(ctx: click.Context, environment: str | None, manifest: str) -> None:
 @click.command()
 @click.option("--environment", default=None, help="Default environment set in config file.")
 @click.option(
-    "--mode",
-    type=click.Choice(["full", "diff"]),
-    default="diff",
-    help="Validate the full manifest, or only the definitions that diff with installed versions",
+    "--only-changed",
+    is_flag=True,
+    default=False,
+    help="Only validate packs that differ from what is currently installed on the server.",
 )
 @click.argument("manifest", type=click.Path(exists=True))
 @click.pass_context
 @load_config
 @validate_artifacts_provider
 @validate_xsoar_connectivity
-def validate(ctx: click.Context, environment: str | None, mode: str, manifest: str) -> None:
+def validate(ctx: click.Context, environment: str | None, only_changed: bool, manifest: str) -> None:
     """Validate manifest JSON and content pack availability.
+
+    By default, validates all packs defined in the manifest. Use --only-changed
+    to limit validation to packs whose version differs from what is currently
+    installed on the server (useful for faster CI runs).
 
     Custom pack availability is implementation dependent."""
     config = get_xsoar_config(ctx)
     xsoar_client: Client = config.get_client(environment)
-    logger.info("Validating manifest '%s' in '%s' mode (environment: '%s')", manifest, mode, environment or config.default_environment)
+    active_env = environment or config.default_environment
+    logger.info(
+        "Validating manifest '%s' (only_changed=%s, environment: '%s')",
+        manifest,
+        only_changed,
+        active_env,
+    )
 
     manifest_data = load_manifest(manifest)
     click.echo("Manifest is valid JSON")
@@ -277,43 +287,34 @@ def validate(ctx: click.Context, environment: str | None, mode: str, manifest: s
         click.echo('Valid keys are "id", "version", "_comment"')
         ctx.exit(1)
 
-    if mode == "full":
-        for key in MANIFEST_KEYS:
-            custom = key == "custom_packs"
-            click.echo(f"Checking {key} availability ", nl=False)
-            _check_pack_availability(
-                xsoar_client,
-                manifest_data[key],
-                custom=custom,
-                manifest_path=manifest,
-            )
-        logger.info("Full validation passed for manifest '%s'", manifest)
-        click.echo("Manifest is valid JSON and all packs are reachable")
-    elif mode == "diff":
+    if only_changed:
         installed_packs = xsoar_client.packs.get_installed()
         installed_by_id = {pack["id"]: pack for pack in installed_packs}
-        for key in MANIFEST_KEYS:
-            custom = key == "custom_packs"
+
+    for key in MANIFEST_KEYS:
+        custom = key == "custom_packs"
+        if only_changed:
             packs_to_check = []
             for pack in manifest_data[key]:
                 installed = installed_by_id.get(pack["id"])
                 if not installed or installed["currentVersion"] != pack["version"]:
                     packs_to_check.append(pack)
-            click.echo(f"Checking {key} availability ", nl=False)
             if not packs_to_check:
-                click.echo("- no diff from installed versions found in manifest.")
-            else:
-                _check_pack_availability(
-                    xsoar_client,
-                    packs_to_check,
-                    custom=custom,
-                    manifest_path=manifest,
-                )
-        logger.info("Diff validation passed for manifest '%s'", manifest)
-        click.echo("Manifest is valid JSON and all packs are reachable.")
-    else:
-        msg = "Invalid value for --mode detected. This should never happen"
-        raise RuntimeError(msg)
+                click.echo(f"Checking {key} availability - no changes found.")
+                continue
+        else:
+            packs_to_check = manifest_data[key]
+
+        click.echo(f"Checking {key} availability ", nl=False)
+        _check_pack_availability(
+            xsoar_client,
+            packs_to_check,
+            custom=custom,
+            manifest_path=manifest,
+        )
+
+    logger.info("Validation passed for manifest '%s'", manifest)
+    click.echo("Manifest is valid JSON and all packs are reachable.")
 
 
 @click.command()

--- a/tests/cli/test_manifest.py
+++ b/tests/cli/test_manifest.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from tests.cli.conftest import InvokeHelper
 
 
@@ -16,3 +19,207 @@ class TestManifestGroup:
     def test_help_flag(self, invoke: InvokeHelper) -> None:
         result = invoke(["manifest", "--help"])
         assert result.exit_code == 0
+
+
+class TestManifestValidate:
+    """Tests for ``manifest validate`` (full validation, default behavior)."""
+
+    def test_valid_manifest_all_packs_reachable(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [{"id": "MyOrg_EDR", "version": "2.0.0"}],
+                    "marketplace_packs": [{"id": "CommonScripts", "version": "1.14.20"}],
+                }
+            )
+        )
+        mock_xsoar_env.client.packs.is_available.return_value = True
+        result = invoke(["manifest", "validate", str(manifest)])
+        assert result.exit_code == 0
+        assert "Manifest is valid JSON" in result.output
+        assert "all packs are reachable" in result.output
+
+    def test_invalid_json(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text("{ invalid json }")
+        result = invoke(["manifest", "validate", str(manifest)])
+        assert result.exit_code != 0
+        assert "Failed to decode JSON" in result.output
+
+    def test_invalid_manifest_keys(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [{"id": "MyOrg_EDR", "version": "2.0.0", "bogus_key": "value"}],
+                    "marketplace_packs": [],
+                }
+            )
+        )
+        result = invoke(["manifest", "validate", str(manifest)])
+        assert result.exit_code != 0
+        assert "invalid key" in result.output
+
+    def test_marketplace_pack_not_reachable(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [],
+                    "marketplace_packs": [{"id": "CommonScripts", "version": "1.14.20"}],
+                }
+            )
+        )
+        mock_xsoar_env.client.packs.is_available.return_value = False
+        result = invoke(["manifest", "validate", str(manifest)])
+        assert result.exit_code != 0
+        assert "Failed to find CommonScripts" in result.output
+
+    def test_checks_both_custom_and_marketplace(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [{"id": "MyOrg_EDR", "version": "2.0.0"}],
+                    "marketplace_packs": [{"id": "CommonScripts", "version": "1.14.20"}],
+                }
+            )
+        )
+        mock_xsoar_env.client.packs.is_available.return_value = True
+        result = invoke(["manifest", "validate", str(manifest)])
+        assert result.exit_code == 0
+        assert "Checking custom_packs availability" in result.output
+        assert "Checking marketplace_packs availability" in result.output
+
+    def test_validates_all_packs_by_default(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        """Default behavior validates every pack, not just changed ones."""
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [],
+                    "marketplace_packs": [
+                        {"id": "CommonScripts", "version": "1.14.20"},
+                        {"id": "Phishing", "version": "3.6.1"},
+                    ],
+                }
+            )
+        )
+        mock_xsoar_env.client.packs.is_available.return_value = True
+        result = invoke(["manifest", "validate", str(manifest)])
+        assert result.exit_code == 0
+        # get_installed should not be called in full validation mode
+        mock_xsoar_env.client.packs.get_installed.assert_not_called()
+        # Both packs should be checked
+        assert mock_xsoar_env.client.packs.is_available.call_count == 2
+
+
+class TestManifestValidateOnlyChanged:
+    """Tests for ``manifest validate --only-changed``."""
+
+    def test_no_changes_skips_availability_check(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [{"id": "MyOrg_EDR", "version": "2.0.0"}],
+                    "marketplace_packs": [{"id": "CommonScripts", "version": "1.14.20"}],
+                }
+            )
+        )
+        mock_xsoar_env.client.packs.get_installed.return_value = [
+            {"id": "MyOrg_EDR", "currentVersion": "2.0.0"},
+            {"id": "CommonScripts", "currentVersion": "1.14.20"},
+        ]
+        result = invoke(["manifest", "validate", "--only-changed", str(manifest)])
+        assert result.exit_code == 0
+        assert "no changes found" in result.output
+        mock_xsoar_env.client.packs.is_available.assert_not_called()
+
+    def test_version_change_triggers_availability_check(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [],
+                    "marketplace_packs": [
+                        {"id": "CommonScripts", "version": "2.0.0"},
+                        {"id": "Phishing", "version": "3.6.1"},
+                    ],
+                }
+            )
+        )
+        mock_xsoar_env.client.packs.get_installed.return_value = [
+            {"id": "CommonScripts", "currentVersion": "1.14.20"},
+            {"id": "Phishing", "currentVersion": "3.6.1"},
+        ]
+        mock_xsoar_env.client.packs.is_available.return_value = True
+        result = invoke(["manifest", "validate", "--only-changed", str(manifest)])
+        assert result.exit_code == 0
+        # Only CommonScripts should be checked (version changed), not Phishing
+        mock_xsoar_env.client.packs.is_available.assert_called_once_with(
+            pack_id="CommonScripts",
+            version="2.0.0",
+            custom=False,
+        )
+
+    def test_new_pack_triggers_availability_check(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [],
+                    "marketplace_packs": [{"id": "NewPack", "version": "1.0.0"}],
+                }
+            )
+        )
+        mock_xsoar_env.client.packs.get_installed.return_value = []
+        mock_xsoar_env.client.packs.is_available.return_value = True
+        result = invoke(["manifest", "validate", "--only-changed", str(manifest)])
+        assert result.exit_code == 0
+        mock_xsoar_env.client.packs.is_available.assert_called_once_with(
+            pack_id="NewPack",
+            version="1.0.0",
+            custom=False,
+        )
+
+    def test_changed_pack_not_reachable(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [],
+                    "marketplace_packs": [{"id": "CommonScripts", "version": "2.0.0"}],
+                }
+            )
+        )
+        mock_xsoar_env.client.packs.get_installed.return_value = [
+            {"id": "CommonScripts", "currentVersion": "1.14.20"},
+        ]
+        mock_xsoar_env.client.packs.is_available.return_value = False
+        result = invoke(["manifest", "validate", "--only-changed", str(manifest)])
+        assert result.exit_code != 0
+        assert "Failed to find CommonScripts" in result.output
+
+    def test_downgrade_triggers_availability_check(self, invoke: InvokeHelper, mock_xsoar_env, tmp_path: Path) -> None:
+        manifest = tmp_path / "xsoar_config.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "custom_packs": [],
+                    "marketplace_packs": [{"id": "CommonScripts", "version": "1.0.0"}],
+                }
+            )
+        )
+        mock_xsoar_env.client.packs.get_installed.return_value = [
+            {"id": "CommonScripts", "currentVersion": "2.0.0"},
+        ]
+        mock_xsoar_env.client.packs.is_available.return_value = True
+        result = invoke(["manifest", "validate", "--only-changed", str(manifest)])
+        assert result.exit_code == 0
+        mock_xsoar_env.client.packs.is_available.assert_called_once_with(
+            pack_id="CommonScripts",
+            version="1.0.0",
+            custom=False,
+        )


### PR DESCRIPTION
Replace --mode with --only-changed in manifest validate

- Change manifest validate to use --only-changed flag instead of --mode
- Default behavior now validates all packs; --only-changed limits to packs that differ from installed versions
- Update help text and logging to reflect new option