### PR TITLE
Configure ruff in pyproject.toml and clean up lint warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.ruff]
+line-length = 140
+extend-exclude = ["tests/mock_content"]
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",

--- a/src/xsoar_cli/xsoar_client/content.py
+++ b/src/xsoar_cli/xsoar_client/content.py
@@ -5,7 +5,6 @@ import tarfile
 from io import BytesIO, StringIO
 from typing import TYPE_CHECKING
 
-from requests.models import Response
 
 if TYPE_CHECKING:
     from .client import Client

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -17,7 +17,7 @@ from xsoar_cli import cli
 
 if TYPE_CHECKING:
     import types
-    from collections.abc import Callable, Iterator
+    from collections.abc import Iterator
 
     from click.testing import Result
 

--- a/tests/cli/test_case.py
+++ b/tests/cli/test_case.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-from requests.exceptions import HTTPError
 
 if TYPE_CHECKING:
     from tests.cli.conftest import InvokeHelper

--- a/tests/unit/test_config_file.py
+++ b/tests/unit/test_config_file.py
@@ -8,7 +8,7 @@ touching the real config file.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import click
 from click.testing import CliRunner
@@ -73,8 +73,6 @@ class TestReadConfigFile:
         assert result is None
 
     def test_returns_parsed_json_when_file_exists(self) -> None:
-        import json
-
         with (
             patch("xsoar_cli.utilities.config_file.get_config_file_path") as mock_path,
             patch("pathlib.Path.is_file", return_value=True),

--- a/tests/unit/test_content_handlers.py
+++ b/tests/unit/test_content_handlers.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-import pytest
 
 from xsoar_cli.utilities.download_content_handlers import (
     HANDLERS,

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import click
-import pytest
 from click.testing import CliRunner
 
 from xsoar_cli.utilities.validators import (
@@ -111,7 +110,7 @@ class TestValidateXsoarConnectivity:
 
         runner = CliRunner()
         with patch("xsoar_cli.utilities.validators.get_xsoar_config", return_value=config):
-            result = runner.invoke(dummy, ["--environment", "prod"], obj=config)
+            runner.invoke(dummy, ["--environment", "prod"], obj=config)
 
         config.get_environment.assert_called_with("prod")
 
@@ -126,7 +125,7 @@ class TestValidateXsoarConnectivity:
 
         runner = CliRunner()
         with patch("xsoar_cli.utilities.validators.get_xsoar_config", return_value=config):
-            result = runner.invoke(dummy, [], obj=config)
+            runner.invoke(dummy, [], obj=config)
 
         config.get_environment.assert_called_with("dev")
 
@@ -198,7 +197,7 @@ class TestValidateArtifactsProvider:
 
         runner = CliRunner()
         with patch("xsoar_cli.utilities.validators.get_xsoar_config", return_value=config):
-            result = runner.invoke(dummy, ["--environment", "staging"], obj=config)
+            runner.invoke(dummy, ["--environment", "staging"], obj=config)
 
         config.get_environment.assert_called_with("staging")
 

--- a/tests/unit/test_version_check.py
+++ b/tests/unit/test_version_check.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from packaging.version import Version
 
 from xsoar_cli.utilities.version_check import (


### PR DESCRIPTION
Centralizes the ruff configuration in `pyproject.toml` so manual CLI invocations, CI, and the editor LSP all use the same rules instead of falling back to ruff's 88-char default.

## Changes

- Add `[tool.ruff]` with `line-length = 140` (matching the project's editor setting) and `extend-exclude = ["tests/mock_content"]` so the mock XSOAR pack fixtures (intentional demisto boilerplate) are not linted or formatted.
- Remove unused imports (F401) across `src/xsoar_cli/xsoar_client/content.py` and several test files.
- Remove unused `result` variables (F841) in `tests/unit/test_validators.py`, keeping the `runner.invoke(...)` side-effect calls.

## Validation

- `uv run ruff check src/ tests/`: clean.
- `uv run ruff format --check src/ tests/`: clean (87 files, 0 reformats).
- `uv run pytest`: 479 passed.

No changelog entry: internal tooling change with no user-facing behavior impact.