### PR TITLE
Refactor content get-detached: human-readable output, fix detached filter, add --type all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `content get-detached --type scripts` now prints a human-readable summary instead of raw JSON. Output is a count followed by one line per item in the form `<name> (ID: <id>)`, or `No detached scripts found` when there are none.
 
+### Fixed
+
+- `content get-detached` now returns only the content items that are actually detached. The previous query returned all system items, so the command reported every system script (or playbook) as detached instead of just the detached ones. Results are now filtered on each item's `detached` field.
+
 ## [2.3.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- `content get-detached` now prints a human-readable summary instead of raw JSON. Output is a count followed by one line per item in the form `<name> (ID: <id>)`, or `No detached <type> found` when there are none. Applies to both `--type scripts` and `--type playbooks`.
+- `content get-detached` now prints a human-readable summary instead of raw JSON. Output is a count followed by one line per item in the form `<name> (ID: <id>)`, or `No detached <type> found` when there are none.
+
+### Added
+
+- `content get-detached --type all` queries both scripts and playbooks and displays results for each type.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- `content get-detached --type scripts` now prints a human-readable summary instead of raw JSON. Output is a count followed by one line per item in the form `<name> (ID: <id>)`, or `No detached scripts found` when there are none.
+- `content get-detached` now prints a human-readable summary instead of raw JSON. Output is a count followed by one line per item in the form `<name> (ID: <id>)`, or `No detached <type> found` when there are none. Applies to both `--type scripts` and `--type playbooks`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `content get-detached --type scripts` now prints a human-readable summary instead of raw JSON. Output is a count followed by one line per item in the form `<name> (ID: <id>)`, or `No detached scripts found` when there are none.
+
 ## [2.3.0] - 2026-06-04
 
 ### Added

--- a/src/xsoar_cli/commands/content/README.md
+++ b/src/xsoar_cli/commands/content/README.md
@@ -12,13 +12,14 @@ The output is a human-readable summary: a count followed by one line per item in
 
 **Options:**
 - `--environment TEXT` - Target environment (default: uses default environment from config)
-- `--type [scripts|playbooks]` - Type of content items to retrieve (required)
+- `--type [scripts|playbooks|all]` - Type of content items to retrieve (required)
 
 **Examples:**
 ```
 xsoar-cli content get-detached --type scripts
+xsoar-cli content get-detached --type playbooks
+xsoar-cli content get-detached --type all
 xsoar-cli content get-detached --type scripts --environment prod
-xsoar-cli content get-detached --type playbooks --environment dev
 ```
 
 ## List

--- a/src/xsoar_cli/commands/content/README.md
+++ b/src/xsoar_cli/commands/content/README.md
@@ -6,7 +6,7 @@ Inspect and manage content items on your XSOAR server.
 
 List detached content items. Detached items are content items that have been modified on the server and are no longer in sync with the installed content pack.
 
-For `--type scripts`, the output is a human-readable summary: a count followed by one line per item in the form `<name> (ID: <id>)`. When no detached scripts are found, the output is `No detached scripts found`. Other types still output JSON formatted with 4-space indentation.
+The output is a human-readable summary: a count followed by one line per item in the form `<name> (ID: <id>)`. When no detached items are found, the output is `No detached <type> found` (for example `No detached scripts found`). This applies to both `--type scripts` and `--type playbooks`.
 
 **Syntax:** `xsoar-cli content get-detached [OPTIONS]`
 

--- a/src/xsoar_cli/commands/content/README.md
+++ b/src/xsoar_cli/commands/content/README.md
@@ -4,19 +4,20 @@ Inspect and manage content items on your XSOAR server.
 
 ## Get Detached
 
-List detached content items. Detached items are content items that are not associated with any installed content pack. Output is JSON formatted with 4-space indentation.
+List detached content items. Detached items are content items that have been modified on the server and are no longer in sync with the installed content pack.
+
+For `--type scripts`, the output is a human-readable summary: a count followed by one line per item in the form `<name> (ID: <id>)`. When no detached scripts are found, the output is `No detached scripts found`. Other types still output JSON formatted with 4-space indentation.
 
 **Syntax:** `xsoar-cli content get-detached [OPTIONS]`
 
 **Options:**
 - `--environment TEXT` - Target environment (default: uses default environment from config)
-- `--type [scripts|playbooks|all]` - Type of content items to retrieve (default: all)
+- `--type [scripts|playbooks]` - Type of content items to retrieve (required)
 
 **Examples:**
 ```
-xsoar-cli content get-detached
-xsoar-cli content get-detached --environment prod
 xsoar-cli content get-detached --type scripts
+xsoar-cli content get-detached --type scripts --environment prod
 xsoar-cli content get-detached --type playbooks --environment dev
 ```
 

--- a/src/xsoar_cli/commands/content/commands.py
+++ b/src/xsoar_cli/commands/content/commands.py
@@ -28,7 +28,7 @@ def content() -> None:
 @click.option(
     "--type",
     "content_type",
-    type=click.Choice(["scripts", "playbooks"], case_sensitive=False),
+    type=click.Choice(["scripts", "playbooks", "all"], case_sensitive=False),
     required=True,
     help="Type of content items to retrieve.",
 )
@@ -39,8 +39,13 @@ def get_detached(ctx: click.Context, environment: str | None, content_type: str)
     """List detached content items."""
     config = get_xsoar_config(ctx)
     xsoar_client: Client = config.get_client(environment)
-    items = xsoar_client.content.get_detached(content_type)
-    click.echo(format_detached_summary(items, content_type))
+
+    types = ["scripts", "playbooks"] if content_type == "all" else [content_type]
+    sections = []
+    for t in types:
+        items = xsoar_client.content.get_detached(t)
+        sections.append(format_detached_summary(items, t))
+    click.echo("\n\n".join(sections))
 
 
 # We name the command in the decorator here to avoid shadowing the builtin list.

--- a/src/xsoar_cli/commands/content/commands.py
+++ b/src/xsoar_cli/commands/content/commands.py
@@ -39,9 +39,7 @@ def get_detached(ctx: click.Context, environment: str | None, content_type: str)
     """List detached content items."""
     config = get_xsoar_config(ctx)
     xsoar_client: Client = config.get_client(environment)
-    response = xsoar_client.content.get_detached(content_type)
-    data = json.loads(response)
-    items = data.get(content_type, [])
+    items = xsoar_client.content.get_detached(content_type)
     click.echo(format_detached_summary(items, content_type))
 
 

--- a/src/xsoar_cli/commands/content/commands.py
+++ b/src/xsoar_cli/commands/content/commands.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import click
 
 from xsoar_cli.utilities.config_file import get_xsoar_config, load_config
-from xsoar_cli.utilities.content import DETAIL_LEVELS, filter_content
+from xsoar_cli.utilities.content import DETAIL_LEVELS, filter_content, format_detached_summary
 from xsoar_cli.utilities.download_content_handlers import HANDLERS, resolve_output_path
 from xsoar_cli.utilities.validators import validate_xsoar_connectivity
 
@@ -41,7 +41,8 @@ def get_detached(ctx: click.Context, environment: str | None, content_type: str)
     xsoar_client: Client = config.get_client(environment)
     response = xsoar_client.content.get_detached(content_type)
     data = json.loads(response)
-    click.echo(json.dumps(data, indent=4))
+    items = data.get(content_type, [])
+    click.echo(format_detached_summary(items, content_type))
 
 
 # We name the command in the decorator here to avoid shadowing the builtin list.

--- a/src/xsoar_cli/utilities/content.py
+++ b/src/xsoar_cli/utilities/content.py
@@ -170,6 +170,29 @@ def filter_commands(instances: list[dict]) -> list[dict]:
     return filtered
 
 
+# -- Detached content --------------------------------------------------------
+
+
+def format_detached_summary(items: list[dict], content_type: str) -> str:
+    """Format a human-readable summary of detached content items.
+
+    *items* is the list of content records returned for a single content type
+    (for example the ``scripts`` list from the detached automation search).
+    *content_type* is the plural label used in the output (for example
+    ``"scripts"``).
+
+    When *items* is empty, returns ``"No detached <content_type> found"``.
+    Otherwise returns a header line with the count followed by one indented
+    line per item in the form ``<name> (ID: <id>)``.
+    """
+    if not items:
+        return f"No detached {content_type} found"
+
+    lines = [f"Found {len(items)} detached {content_type}:"]
+    lines.extend(f"  {item.get('name', '')} (ID: {item.get('id', '')})" for item in items)
+    return "\n".join(lines)
+
+
 DETAIL_LEVELS = ("short", "extended", "full")
 
 

--- a/src/xsoar_cli/xsoar_client/content.py
+++ b/src/xsoar_cli/xsoar_client/content.py
@@ -5,7 +5,6 @@ import tarfile
 from io import BytesIO, StringIO
 from typing import TYPE_CHECKING
 
-
 if TYPE_CHECKING:
     from .client import Client
 
@@ -34,9 +33,16 @@ class Content:
                     loaded_files[file_name] = file_data
         return loaded_files
 
-    def get_detached(self, content_type: str | None) -> bytes:
-        """Returns detached content. Currently supports script, playbooks, layouts.
-        Where content_type must be either "playbooks" or "scripts".
+    def get_detached(self, content_type: str | None) -> list[dict]:
+        """Returns detached content items of the given type.
+
+        *content_type* must be either "scripts" or "playbooks".
+
+        The search query ("system:T") returns all system (detachable) items,
+        not just the detached ones, so the results are filtered client-side on
+        the per-item "detached" field. An item is considered detached when the
+        field is truthy and not the string "false". This mirrors how
+        demisto-sdk identifies detached items (see ItemReattacher.reattach).
         """
         payload = {"query": "system:T"}
         if content_type == "scripts":
@@ -47,7 +53,15 @@ class Content:
             raise ValueError(f"Invalid value {content_type=}")
         response = self.client.make_request(endpoint=endpoint, method="POST", json=payload)
         response.raise_for_status()
-        return response.content
+
+        items = response.json().get(content_type) or []
+        detached_items: list[dict] = []
+        for item in items:
+            detached = item.get("detached", "")
+            if not detached or detached == "false":
+                continue
+            detached_items.append(item)
+        return detached_items
 
     def attach_item(self, item_type: str, item_id: str) -> None:
         """Attaches a content item to the server-managed version."""

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -87,7 +87,8 @@ def mock_content_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # no
     """Mock environment for ``content download`` commands.
 
     Patches connectivity, ``Content`` download methods, ``subprocess.run``
-    (for demisto-sdk format), and ``Content.attach_item``.
+    (for demisto-sdk format), ``Content.attach_item``, and
+    ``Content.get_detached``.
 
     Yields a ``SimpleNamespace`` with attributes:
 
@@ -97,6 +98,7 @@ def mock_content_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # no
     * ``attach`` -- the ``Content.attach_item`` mock
     * ``download_playbook`` -- the ``Content.download_playbook`` mock
     * ``download_layout`` -- the ``Content.download_layout`` mock
+    * ``get_detached`` -- the ``Content.get_detached`` mock
 
     Example::
 
@@ -113,6 +115,7 @@ def mock_content_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # no
         patch("xsoar_cli.xsoar_client.content.Content.attach_item") as mock_attach,
         patch("xsoar_cli.xsoar_client.content.Content.download_playbook") as mock_dl_pb,
         patch("xsoar_cli.xsoar_client.content.Content.download_layout") as mock_dl_layout,
+        patch("xsoar_cli.xsoar_client.content.Content.get_detached") as mock_get_detached,
     ):
         ns = _types.SimpleNamespace(
             config=mock_config_file,
@@ -121,6 +124,7 @@ def mock_content_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # no
             attach=mock_attach,
             download_playbook=mock_dl_pb,
             download_layout=mock_dl_layout,
+            get_detached=mock_get_detached,
         )
         yield ns
 

--- a/tests/cli/test_content.py
+++ b/tests/cli/test_content.py
@@ -266,3 +266,22 @@ class TestContentGetDetached:
         assert "Found 2 detached playbooks:" in result.output
         assert "  Playbook One (ID: pb1)" in result.output
         assert "  Playbook Two (ID: pb2)" in result.output
+
+    def test_all_shows_both_types(self, invoke: InvokeHelper, mock_content_env) -> None:
+        mock_content_env.get_detached.side_effect = [
+            [{"id": "s1", "name": "Script One"}],
+            [{"id": "pb1", "name": "Playbook One"}, {"id": "pb2", "name": "Playbook Two"}],
+        ]
+        result = invoke(["content", "get-detached", "--type", "all"])
+        assert result.exit_code == 0
+        assert "Found 1 detached scripts:" in result.output
+        assert "  Script One (ID: s1)" in result.output
+        assert "Found 2 detached playbooks:" in result.output
+        assert "  Playbook One (ID: pb1)" in result.output
+
+    def test_all_both_empty(self, invoke: InvokeHelper, mock_content_env) -> None:
+        mock_content_env.get_detached.side_effect = [[], []]
+        result = invoke(["content", "get-detached", "--type", "all"])
+        assert result.exit_code == 0
+        assert "No detached scripts found" in result.output
+        assert "No detached playbooks found" in result.output

--- a/tests/cli/test_content.py
+++ b/tests/cli/test_content.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -235,19 +234,16 @@ class TestContentGetDetachedScripts:
     """Tests for ``content get-detached --type scripts``."""
 
     def test_no_detached_scripts(self, invoke: InvokeHelper, mock_content_env) -> None:
-        mock_content_env.get_detached.return_value = json.dumps({"scripts": []}).encode()
+        mock_content_env.get_detached.return_value = []
         result = invoke(["content", "get-detached", "--type", "scripts"])
         assert result.exit_code == 0
         assert result.output.strip() == "No detached scripts found"
 
     def test_detached_scripts_listed(self, invoke: InvokeHelper, mock_content_env) -> None:
-        scripts = {
-            "scripts": [
-                {"id": "id1", "name": "Script One"},
-                {"id": "id2", "name": "Script Two"},
-            ]
-        }
-        mock_content_env.get_detached.return_value = json.dumps(scripts).encode()
+        mock_content_env.get_detached.return_value = [
+            {"id": "id1", "name": "Script One"},
+            {"id": "id2", "name": "Script Two"},
+        ]
         result = invoke(["content", "get-detached", "--type", "scripts"])
         assert result.exit_code == 0
         assert "Found 2 detached scripts:" in result.output

--- a/tests/cli/test_content.py
+++ b/tests/cli/test_content.py
@@ -230,8 +230,8 @@ class TestContentDownloadMissingType:
         assert "Missing option '--type'" in result.output
 
 
-class TestContentGetDetachedScripts:
-    """Tests for ``content get-detached --type scripts``."""
+class TestContentGetDetached:
+    """Tests for ``content get-detached``."""
 
     def test_no_detached_scripts(self, invoke: InvokeHelper, mock_content_env) -> None:
         mock_content_env.get_detached.return_value = []
@@ -249,3 +249,20 @@ class TestContentGetDetachedScripts:
         assert "Found 2 detached scripts:" in result.output
         assert "  Script One (ID: id1)" in result.output
         assert "  Script Two (ID: id2)" in result.output
+
+    def test_no_detached_playbooks(self, invoke: InvokeHelper, mock_content_env) -> None:
+        mock_content_env.get_detached.return_value = []
+        result = invoke(["content", "get-detached", "--type", "playbooks"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "No detached playbooks found"
+
+    def test_detached_playbooks_listed(self, invoke: InvokeHelper, mock_content_env) -> None:
+        mock_content_env.get_detached.return_value = [
+            {"id": "pb1", "name": "Playbook One"},
+            {"id": "pb2", "name": "Playbook Two"},
+        ]
+        result = invoke(["content", "get-detached", "--type", "playbooks"])
+        assert result.exit_code == 0
+        assert "Found 2 detached playbooks:" in result.output
+        assert "  Playbook One (ID: pb1)" in result.output
+        assert "  Playbook Two (ID: pb2)" in result.output

--- a/tests/cli/test_content.py
+++ b/tests/cli/test_content.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -228,3 +229,27 @@ class TestContentDownloadMissingType:
         result = invoke(["content", "download", "SomeName"])
         assert result.exit_code != 0
         assert "Missing option '--type'" in result.output
+
+
+class TestContentGetDetachedScripts:
+    """Tests for ``content get-detached --type scripts``."""
+
+    def test_no_detached_scripts(self, invoke: InvokeHelper, mock_content_env) -> None:
+        mock_content_env.get_detached.return_value = json.dumps({"scripts": []}).encode()
+        result = invoke(["content", "get-detached", "--type", "scripts"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "No detached scripts found"
+
+    def test_detached_scripts_listed(self, invoke: InvokeHelper, mock_content_env) -> None:
+        scripts = {
+            "scripts": [
+                {"id": "id1", "name": "Script One"},
+                {"id": "id2", "name": "Script Two"},
+            ]
+        }
+        mock_content_env.get_detached.return_value = json.dumps(scripts).encode()
+        result = invoke(["content", "get-detached", "--type", "scripts"])
+        assert result.exit_code == 0
+        assert "Found 2 detached scripts:" in result.output
+        assert "  Script One (ID: id1)" in result.output
+        assert "  Script Two (ID: id2)" in result.output

--- a/tests/unit/test_content_domain.py
+++ b/tests/unit/test_content_domain.py
@@ -293,6 +293,7 @@ class TestGetDetached:
         mock_client = MagicMock()
         response = MagicMock()
         response.raise_for_status.return_value = None
+        response.json.return_value = {"scripts": []}
         mock_client.make_request.return_value = response
 
         content = Content(mock_client)
@@ -308,6 +309,7 @@ class TestGetDetached:
         mock_client = MagicMock()
         response = MagicMock()
         response.raise_for_status.return_value = None
+        response.json.return_value = {"playbooks": []}
         mock_client.make_request.return_value = response
 
         content = Content(mock_client)
@@ -323,12 +325,53 @@ class TestGetDetached:
         mock_client = MagicMock()
         response = MagicMock()
         response.raise_for_status.return_value = None
+        response.json.return_value = {"scripts": []}
         mock_client.make_request.return_value = response
 
         content = Content(mock_client)
         content.get_detached("scripts")
 
         response.raise_for_status.assert_called_once()
+
+    def test_filters_to_detached_items_only(self) -> None:
+        mock_client = MagicMock()
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "scripts": [
+                {"id": "a", "name": "A", "detached": True},
+                {"id": "b", "name": "B", "detached": False},
+                {"id": "c", "name": "C"},
+                {"id": "d", "name": "D", "detached": "false"},
+                {"id": "e", "name": "E", "detached": None},
+            ]
+        }
+        mock_client.make_request.return_value = response
+
+        content = Content(mock_client)
+        result = content.get_detached("scripts")
+
+        assert [item["id"] for item in result] == ["a"]
+
+    def test_returns_empty_list_when_none_detached(self) -> None:
+        mock_client = MagicMock()
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"scripts": [{"id": "a", "name": "A", "detached": False}]}
+        mock_client.make_request.return_value = response
+
+        content = Content(mock_client)
+        assert content.get_detached("scripts") == []
+
+    def test_missing_type_key_returns_empty_list(self) -> None:
+        mock_client = MagicMock()
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {}
+        mock_client.make_request.return_value = response
+
+        content = Content(mock_client)
+        assert content.get_detached("scripts") == []
 
     def test_invalid_content_type_raises(self) -> None:
         mock_client = MagicMock()

--- a/tests/unit/test_content_filters.py
+++ b/tests/unit/test_content_filters.py
@@ -13,6 +13,7 @@ from xsoar_cli.utilities.content import (
     filter_content,
     filter_playbooks,
     filter_scripts,
+    format_detached_summary,
     summarize_commands,
     summarize_playbooks,
     summarize_scripts,
@@ -372,3 +373,32 @@ class TestFilterContent:
     def test_unknown_keys_ignored(self) -> None:
         raw = {"unknown": [{"id": "1"}]}
         assert filter_content(raw) == {}
+
+
+class TestFormatDetachedSummary:
+    """Tests for ``format_detached_summary``."""
+
+    def test_empty_returns_not_found_message(self) -> None:
+        assert format_detached_summary([], "scripts") == "No detached scripts found"
+
+    def test_single_item(self) -> None:
+        items = [{"id": "SetAndHandleEmpty", "name": "SetAndHandleEmpty"}]
+        result = format_detached_summary(items, "scripts")
+        assert result == "Found 1 detached scripts:\n  SetAndHandleEmpty (ID: SetAndHandleEmpty)"
+
+    def test_multiple_items(self) -> None:
+        items = [
+            {"id": "id1", "name": "Script One"},
+            {"id": "id2", "name": "Script Two"},
+        ]
+        result = format_detached_summary(items, "scripts")
+        expected = "Found 2 detached scripts:\n  Script One (ID: id1)\n  Script Two (ID: id2)"
+        assert result == expected
+
+    def test_missing_fields_default_to_empty(self) -> None:
+        items = [{}]
+        result = format_detached_summary(items, "scripts")
+        assert result == "Found 1 detached scripts:\n   (ID: )"
+
+    def test_content_type_label_used(self) -> None:
+        assert format_detached_summary([], "playbooks") == "No detached playbooks found"


### PR DESCRIPTION
Refactors the `content get-detached` command with four changes, each in its own commit.

## Commits

### 1. Add human-readable summary for `content get-detached --type scripts`

Replace the raw JSON output with a summary: a count followed by one line per item in the form `<name> (ID: <id>)`, or `No detached scripts found` when there are none. Adds a `format_detached_summary` helper in `utilities/content.py`.

### 2. Fix `content get-detached` returning non-detached items

The search query (`system:T`) returns all system (detachable) items, not just the detached ones. `Content.get_detached` now filters results on each item's `detached` field (truthy and not the string `"false"`), matching how demisto-sdk identifies detached items. The method returns a filtered `list[dict]` instead of raw bytes.

### 3. Document and test get-detached summary for playbooks

The filtering and summary output already work for both scripts and playbooks. Updates the README and changelog to reflect this, and adds CLI tests for `--type playbooks`.

### 4. Add `--type all` option to `content get-detached`

Queries both scripts and playbooks and displays a summary for each type, separated by a blank line. Both sections are always shown, including when one or both types have no detached items.

## Validation

- `uv run pytest`: 489 passed (after commit 2), 28 content tests (after commit 4).
- `ruff check src/ tests/`: clean.
- `ruff format --check src/ tests/`: clean.
- Verified against live XSOAR: correctly reports 2 detached scripts and 19 detached playbooks (previously reported all 749 system scripts).