### PR TITLE
Rework content list and add content describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `content get-detached --type all` queries both scripts and playbooks and displays results for each type.
 - `content list --output-format` option (choices: `table`, `json`, `plain`, default: `table`). `table` is human-readable aligned columns, `json` is machine-readable, and `plain` is tab-separated values suitable for piping to tools like `grep`.
 - `content list --search TERM` option. Filters the listed items with a case-insensitive substring match against each item's id, name, and description. Content types and integration brands with no matching items are omitted, and a `No content matching '<term>' found.` message is shown when nothing matches.
+- `content describe --type [script|playbook|command] NAME` command. Shows a single content item in detail: description, arguments, and inputs/outputs. Commands also show the integration brand and its configured instances (name and state). Supports `--output-format [table|json]` (default: `table`). See the [content README](src/xsoar_cli/commands/content/README.md) for details.
 
 ### Changed
 
@@ -21,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
-- **Breaking:** `content list --detail-level` option, along with its `short`, `extended`, and `full` levels. `content list` now always produces a curated summary. Per-item detail (arguments, inputs, outputs) will be available through the forthcoming `content describe` command.
+- **Breaking:** `content list --detail-level` option, along with its `short`, `extended`, and `full` levels. `content list` now always produces a curated summary. Per-item detail (arguments, inputs, outputs) is available through the `content describe` command.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `content get-detached --type all` queries both scripts and playbooks and displays results for each type.
 - `content list --output-format` option (choices: `table`, `json`, `plain`, default: `table`). `table` is human-readable aligned columns, `json` is machine-readable, and `plain` is tab-separated values suitable for piping to tools like `grep`.
+- `content list --search TERM` option. Filters the listed items with a case-insensitive substring match against each item's id, name, and description. Content types and integration brands with no matching items are omitted, and a `No content matching '<term>' found.` message is shown when nothing matches.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Changed
-
-- `content get-detached` now prints a human-readable summary instead of raw JSON. Output is a count followed by one line per item in the form `<name> (ID: <id>)`, or `No detached <type> found` when there are none.
-
 ### Added
 
 - `content get-detached --type all` queries both scripts and playbooks and displays results for each type.
+- `content list --output-format` option (choices: `table`, `json`, `plain`, default: `table`). `table` is human-readable aligned columns, `json` is machine-readable, and `plain` is tab-separated values suitable for piping to tools like `grep`.
+
+### Changed
+
+- `content get-detached` now prints a human-readable summary instead of raw JSON. Output is a count followed by one line per item in the form `<name> (ID: <id>)`, or `No detached <type> found` when there are none.
+- **Breaking:** `content list` now defaults to a human-readable table instead of JSON. Use `--output-format json` for machine-readable output.
+- `content list` playbook output now shows the playbook ID and description (read from the `comment` field) instead of the name and ID.
+- `content list` command output now shows the command name and description and no longer includes the integration brand. The summary-level JSON structure for commands is now a list of `{name, description}` objects instead of plain command-name strings.
+
+### Removed
+
+- **Breaking:** `content list --detail-level` option, along with its `short`, `extended`, and `full` levels. `content list` now always produces a curated summary. Per-item detail (arguments, inputs, outputs) will be available through the forthcoming `content describe` command.
 
 ### Fixed
 

--- a/src/xsoar_cli/commands/content/README.md
+++ b/src/xsoar_cli/commands/content/README.md
@@ -33,6 +33,7 @@ By default the output is a human-readable table. Use `--output-format json` for 
 **Options:**
 - `--environment TEXT` - Target environment (default: uses default environment from config)
 - `--type [scripts|playbooks|commands|all]` - Type of content items to list (default: all)
+- `--search TEXT` - Case-insensitive substring filter on item id, name, and description
 - `--output-format [table|json|plain]` - Output format (default: table)
 
 **Examples:**
@@ -40,6 +41,7 @@ By default the output is a human-readable table. Use `--output-format json` for 
 xsoar-cli content list
 xsoar-cli content list --environment prod
 xsoar-cli content list --type commands
+xsoar-cli content list --type commands --search slack
 xsoar-cli content list --type commands --output-format json
 xsoar-cli content list --type scripts --output-format plain
 xsoar-cli content list --type playbooks --environment dev

--- a/src/xsoar_cli/commands/content/README.md
+++ b/src/xsoar_cli/commands/content/README.md
@@ -24,21 +24,24 @@ xsoar-cli content get-detached --type scripts --environment prod
 
 ## List
 
-List available content items. Enumerates commands, playbooks and scripts available on the server. Output is JSON formatted with 4-space indentation.
+List available content items. Enumerates commands, playbooks and scripts available on the server. Designed for discovery: a quick, scannable overview of what content exists, primarily to help humans and AI agents identify relevant items before working with them.
+
+By default the output is a human-readable table. Use `--output-format json` for machine-readable output, or `--output-format plain` for tab-separated values that are easy to pipe to tools like `grep`.
 
 **Syntax:** `xsoar-cli content list [OPTIONS]`
 
 **Options:**
 - `--environment TEXT` - Target environment (default: uses default environment from config)
 - `--type [scripts|playbooks|commands|all]` - Type of content items to list (default: all)
-- `--detail-level [short|extended|full]` - Amount of detail in the output (default: short)
+- `--output-format [table|json|plain]` - Output format (default: table)
 
 **Examples:**
 ```
 xsoar-cli content list
 xsoar-cli content list --environment prod
 xsoar-cli content list --type commands
-xsoar-cli content list --type commands --detail-level extended
+xsoar-cli content list --type commands --output-format json
+xsoar-cli content list --type scripts --output-format plain
 xsoar-cli content list --type playbooks --environment dev
 ```
 

--- a/src/xsoar_cli/commands/content/README.md
+++ b/src/xsoar_cli/commands/content/README.md
@@ -47,6 +47,27 @@ xsoar-cli content list --type scripts --output-format plain
 xsoar-cli content list --type playbooks --environment dev
 ```
 
+## Describe
+
+Describe a single content item in detail. Looks up one script, playbook, or command by name and shows its description, arguments, and inputs/outputs. Commands also show the integration brand and its configured instances (name and state). Use this after `content list` to get the detail needed to actually use an item.
+
+The lookup is case-insensitive. Scripts match on id, playbooks match on id or name (so a custom playbook with a UUID id resolves by its human-readable name), and commands match on the command name.
+
+**Syntax:** `xsoar-cli content describe --type TYPE NAME`
+
+**Options:**
+- `--environment TEXT` - Target environment (default: uses default environment from config)
+- `--type [script|playbook|command]` - Type of content item to describe (required)
+- `--output-format [table|json]` - Output format (default: table)
+
+**Examples:**
+```
+xsoar-cli content describe --type command servicenow-get-record
+xsoar-cli content describe --type script AddDNBHostIndicatorToCase
+xsoar-cli content describe --type playbook "Phishing Investigation - Generic v2"
+xsoar-cli content describe --type command servicenow-get-record --output-format json
+```
+
 ## Download
 
 Download a content item by name from the XSOAR server.

--- a/src/xsoar_cli/commands/content/commands.py
+++ b/src/xsoar_cli/commands/content/commands.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING
 import click
 
 from xsoar_cli.utilities.config_file import get_xsoar_config, load_config
-from xsoar_cli.utilities.content import filter_content, format_detached_summary, search_content
+from xsoar_cli.utilities.content import describe_item, filter_content, format_detached_summary, search_content
 from xsoar_cli.utilities.download_content_handlers import HANDLERS, resolve_output_path
-from xsoar_cli.utilities.output import OUTPUT_FORMATS, format_content_output
+from xsoar_cli.utilities.output import DESCRIBE_OUTPUT_FORMATS, OUTPUT_FORMATS, format_content_output, format_describe
 from xsoar_cli.utilities.validators import validate_xsoar_connectivity
 
 if TYPE_CHECKING:
@@ -102,6 +102,46 @@ def list_content(ctx: click.Context, environment: str | None, content_type: str,
 @click.option(
     "--type",
     "content_type",
+    type=click.Choice(["script", "playbook", "command"], case_sensitive=False),
+    required=True,
+    help="Type of content item to describe.",
+)
+@click.option(
+    "--output-format",
+    type=click.Choice(DESCRIBE_OUTPUT_FORMATS, case_sensitive=False),
+    default="table",
+    show_default=True,
+    help="Output format. Use 'json' for machine-readable output.",
+)
+@click.argument("name", type=str)
+@click.pass_context
+@load_config
+@validate_xsoar_connectivity
+def describe(ctx: click.Context, environment: str | None, content_type: str, output_format: str, name: str) -> None:
+    """Describe a single content item in detail.
+
+    Looks up one script, playbook, or command by name and shows its
+    description, arguments, and inputs/outputs. Commands also show the
+    integration brand and its configured instances. Use this after
+    'content list' to get the detail needed to actually use an item.
+    """
+    config = get_xsoar_config(ctx)
+    xsoar_client: Client = config.get_client(environment)
+    raw = xsoar_client.content.describe(content_type, name)
+    if raw is None:
+        click.echo(f"Error: {content_type} '{name}' not found")
+        ctx.exit(1)
+        return
+
+    item = describe_item(content_type, raw)
+    click.echo(format_describe(content_type, item, output_format=output_format))
+
+
+@click.command()
+@click.option("--environment", default=None, help="Default environment set in config file.")
+@click.option(
+    "--type",
+    "content_type",
     type=click.Choice(sorted(HANDLERS.keys()), case_sensitive=False),
     required=True,
     help="Type of content item to download.",
@@ -187,4 +227,5 @@ def download(ctx: click.Context, environment: str | None, content_type: str, out
 
 content.add_command(get_detached)
 content.add_command(list_content)
+content.add_command(describe)
 content.add_command(download)

--- a/src/xsoar_cli/commands/content/commands.py
+++ b/src/xsoar_cli/commands/content/commands.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import pathlib
 import subprocess
@@ -7,8 +6,9 @@ from typing import TYPE_CHECKING
 import click
 
 from xsoar_cli.utilities.config_file import get_xsoar_config, load_config
-from xsoar_cli.utilities.content import DETAIL_LEVELS, filter_content, format_detached_summary
+from xsoar_cli.utilities.content import filter_content, format_detached_summary
 from xsoar_cli.utilities.download_content_handlers import HANDLERS, resolve_output_path
+from xsoar_cli.utilities.output import OUTPUT_FORMATS, format_content_output
 from xsoar_cli.utilities.validators import validate_xsoar_connectivity
 
 if TYPE_CHECKING:
@@ -60,16 +60,16 @@ def get_detached(ctx: click.Context, environment: str | None, content_type: str)
     help="Type of content items to list.",
 )
 @click.option(
-    "--detail-level",
-    type=click.Choice(DETAIL_LEVELS, case_sensitive=False),
-    default="short",
+    "--output-format",
+    type=click.Choice(OUTPUT_FORMATS, case_sensitive=False),
+    default="table",
     show_default=True,
-    help="Amount of detail to include in the output.",
+    help="Output format. Use 'json' for machine-readable output.",
 )
 @click.pass_context
 @load_config
 @validate_xsoar_connectivity
-def list_content(ctx: click.Context, environment: str | None, content_type: str, detail_level: str) -> None:
+def list_content(ctx: click.Context, environment: str | None, content_type: str, output_format: str) -> None:
     """
     List available content items. Enumerates commands, playbooks and scripts
     available on the server, primarily to facilitate better AI generated
@@ -77,16 +77,13 @@ def list_content(ctx: click.Context, environment: str | None, content_type: str,
     config = get_xsoar_config(ctx)
     xsoar_client: Client = config.get_client(environment)
     json_blob = xsoar_client.content.list(content_type)
-    if detail_level == "full":
-        click.echo(json.dumps(json_blob, indent=4))
-        ctx.exit(0)
 
     # Individual type calls return a bare list, normalize to dict for filter_content.
     if isinstance(json_blob, list):
         json_blob = {content_type: json_blob}
 
-    filtered = filter_content(json_blob, detail_level=detail_level)
-    click.echo(json.dumps(filtered, indent=4))
+    filtered = filter_content(json_blob)
+    click.echo(format_content_output(filtered, output_format=output_format))
 
 
 @click.command()

--- a/src/xsoar_cli/commands/content/commands.py
+++ b/src/xsoar_cli/commands/content/commands.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import click
 
 from xsoar_cli.utilities.config_file import get_xsoar_config, load_config
-from xsoar_cli.utilities.content import filter_content, format_detached_summary
+from xsoar_cli.utilities.content import filter_content, format_detached_summary, search_content
 from xsoar_cli.utilities.download_content_handlers import HANDLERS, resolve_output_path
 from xsoar_cli.utilities.output import OUTPUT_FORMATS, format_content_output
 from xsoar_cli.utilities.validators import validate_xsoar_connectivity
@@ -60,6 +60,11 @@ def get_detached(ctx: click.Context, environment: str | None, content_type: str)
     help="Type of content items to list.",
 )
 @click.option(
+    "--search",
+    default=None,
+    help="Case-insensitive substring filter on item id, name, and description.",
+)
+@click.option(
     "--output-format",
     type=click.Choice(OUTPUT_FORMATS, case_sensitive=False),
     default="table",
@@ -69,7 +74,7 @@ def get_detached(ctx: click.Context, environment: str | None, content_type: str)
 @click.pass_context
 @load_config
 @validate_xsoar_connectivity
-def list_content(ctx: click.Context, environment: str | None, content_type: str, output_format: str) -> None:
+def list_content(ctx: click.Context, environment: str | None, content_type: str, search: str | None, output_format: str) -> None:
     """
     List available content items. Enumerates commands, playbooks and scripts
     available on the server, primarily to facilitate better AI generated
@@ -83,6 +88,12 @@ def list_content(ctx: click.Context, environment: str | None, content_type: str,
         json_blob = {content_type: json_blob}
 
     filtered = filter_content(json_blob)
+    if search:
+        filtered = search_content(filtered, search)
+        if not filtered:
+            click.echo(f"No content matching '{search}' found.")
+            return
+
     click.echo(format_content_output(filtered, output_format=output_format))
 
 

--- a/src/xsoar_cli/utilities/content.py
+++ b/src/xsoar_cli/utilities/content.py
@@ -273,3 +273,31 @@ def search_content(summary: dict, term: str) -> dict:
             result["commands"] = groups
 
     return result
+
+
+def describe_item(item_type: str, raw: dict) -> dict:
+    """Reduce a single raw content item to its actionable detail.
+
+    *item_type* is ``script``, ``playbook``, or ``command`` (singular).
+    *raw* is the record returned by ``Content.describe()``. For commands the
+    raw record wraps the command in ``{brand, instances, command}``; the
+    reduced result flattens that into the command fields plus ``brand`` and
+    ``instances``.
+    """
+    if item_type == "script":
+        return filter_scripts([raw])[0]
+    if item_type == "playbook":
+        return filter_playbooks([raw])[0]
+    if item_type == "command":
+        brand = raw.get("brand", "")
+        instances = raw.get("instances", [])
+        reduced = filter_commands([{"brand": brand, "commands": [raw.get("command", {})]}])[0]["commands"][0]
+        return {
+            "name": reduced["name"],
+            "brand": brand,
+            "instances": instances,
+            "description": reduced["description"],
+            "arguments": reduced["arguments"],
+            "outputs": reduced["outputs"],
+        }
+    raise ValueError(f"Invalid value {item_type=}")

--- a/src/xsoar_cli/utilities/content.py
+++ b/src/xsoar_cli/utilities/content.py
@@ -220,3 +220,56 @@ def filter_content(raw: dict) -> dict:
         result["commands"] = summarize_commands(raw["commands"])
 
     return result
+
+
+_SEARCH_FIELDS = ("id", "name", "comment", "description")
+
+
+def _item_matches(item: dict, term: str) -> bool:
+    """Return True if *term* is a substring of any searchable field on *item*.
+
+    The match is case-insensitive and checks ``id``, ``name``, ``comment``,
+    and ``description`` (whichever are present). *term* is expected to be
+    already lowercased.
+    """
+    return any(term in str(item.get(field, "")).lower() for field in _SEARCH_FIELDS)
+
+
+def search_content(summary: dict, term: str) -> dict:
+    """Filter a content summary down to items matching *term*.
+
+    *summary* is the dict produced by ``filter_content()``. The match is a
+    case-insensitive substring test against each item's ``id``, ``name``,
+    ``comment``, and ``description`` fields (whichever are present).
+
+    For scripts and playbooks, non-matching items are dropped. For commands,
+    only matching commands are kept within each brand group, and brand groups
+    left with no matching commands are dropped. Content types left with no
+    matches are omitted from the result entirely.
+
+    When *term* is empty, the summary is returned unchanged.
+    """
+    if not term:
+        return summary
+
+    needle = term.lower()
+    result: dict = {}
+
+    for content_type in ("scripts", "playbooks"):
+        items = summary.get(content_type)
+        if items is None:
+            continue
+        matches = [item for item in items if _item_matches(item, needle)]
+        if matches:
+            result[content_type] = matches
+
+    if "commands" in summary:
+        groups: list[dict] = []
+        for group in summary["commands"]:
+            matching = [cmd for cmd in group.get("commands", []) if _item_matches(cmd, needle)]
+            if matching:
+                groups.append({"brand": group.get("brand", ""), "commands": matching})
+        if groups:
+            result["commands"] = groups
+
+    return result

--- a/src/xsoar_cli/utilities/content.py
+++ b/src/xsoar_cli/utilities/content.py
@@ -5,15 +5,13 @@ than downstream consumers (especially LLM-based tooling) need. The functions
 in this module strip each content type down to the fields that matter while
 keeping the output structure extensible.
 
-Three detail levels are available:
+``content list`` uses the ``summarize_*`` functions to produce a compact
+id/comment summary per item, designed for discovery where a consumer scans
+the list to identify relevant items.
 
-- **short** (default): compact id/name representation per item. Designed for
-  discovery, where an LLM scans the full list to identify relevant items.
-- **extended**: includes inputs, outputs, and arguments reduced to the fields
-  that matter. Intended for retrieving actionable detail on a smaller set of
-  items.
-- **full**: the raw, unfiltered API response. Handled by the CLI command
-  before calling into this module.
+The ``filter_*`` functions reduce each item to its actionable detail
+(arguments, inputs, outputs). They are reserved for the ``content describe``
+command, which presents a single item in depth.
 """
 
 from __future__ import annotations
@@ -60,15 +58,16 @@ def filter_scripts(scripts: list[dict]) -> list[dict]:
 
 
 def summarize_playbooks(playbooks: list[dict]) -> list[dict]:
-    """Return an id + name summary for each playbook.
+    """Return an id + comment summary for each playbook.
 
-    Playbook IDs are UUIDs, so the human-readable ``name`` field is included
-    to make the summary useful for discovery.
+    The ``comment`` field holds the playbook description and matches the
+    field name used by scripts, keeping the structure consistent across
+    content types.
     """
     return [
         {
             "id": playbook.get("id", ""),
-            "name": playbook.get("name", ""),
+            "comment": playbook.get("comment", ""),
         }
         for playbook in playbooks
     ]
@@ -77,7 +76,7 @@ def summarize_playbooks(playbooks: list[dict]) -> list[dict]:
 def filter_playbooks(playbooks: list[dict]) -> list[dict]:
     """Return a detailed (but still filtered) representation of each playbook.
 
-    Keeps ``id``, ``name``, ``inputs`` (reduced to ``key`` and
+    Keeps ``id``, ``comment``, ``inputs`` (reduced to ``key`` and
     ``description``), and ``outputs`` (reduced to ``contextPath``,
     ``description``, ``type``). The ``tasks`` blob is excluded because it
     dominates the response size and is not useful for deciding whether to
@@ -93,7 +92,7 @@ def filter_playbooks(playbooks: list[dict]) -> list[dict]:
         filtered.append(
             {
                 "id": playbook.get("id", ""),
-                "name": playbook.get("name", ""),
+                "comment": playbook.get("comment", ""),
                 "inputs": [{key: inp.get(key) for key in input_keys} for inp in inputs],
                 "outputs": [{key: out.get(key) for key in output_keys} for out in outputs],
             }
@@ -120,15 +119,24 @@ def _group_commands_by_brand(instances: list[dict]) -> list[dict]:
 
 
 def summarize_commands(instances: list[dict]) -> list[dict]:
-    """Return a brand + command name summary for each integration.
+    """Return a brand + command summary for each integration.
 
-    Deduplicates by brand and reduces each command to just its name.
+    Deduplicates by brand and reduces each command to ``name`` and
+    ``description``. Returning objects (rather than plain name strings)
+    keeps the structure consistent with ``filter_commands`` so formatters
+    do not need to handle both shapes.
     """
     grouped = _group_commands_by_brand(instances)
     return [
         {
             "brand": instance.get("brand", ""),
-            "commands": [cmd.get("name", "") for cmd in instance.get("commands") or []],
+            "commands": [
+                {
+                    "name": cmd.get("name", ""),
+                    "description": cmd.get("description", ""),
+                }
+                for cmd in instance.get("commands") or []
+            ],
         }
         for instance in grouped
     ]
@@ -193,41 +201,22 @@ def format_detached_summary(items: list[dict], content_type: str) -> str:
     return "\n".join(lines)
 
 
-DETAIL_LEVELS = ("short", "extended", "full")
-
-
-def filter_content(raw: dict, *, detail_level: str = "short") -> dict:
-    """Dispatch filtering for each content type present in *raw*.
+def filter_content(raw: dict) -> dict:
+    """Produce a compact id/comment summary for each content type in *raw*.
 
     ``raw`` is the dict returned by ``xsoar_client.content.list()`` and may
     contain any combination of ``scripts``, ``playbooks``, and ``commands``
     keys depending on the requested type.
-
-    *detail_level* controls how much information is kept:
-
-    - ``"short"``: compact id/name summary only.
-    - ``"extended"``: includes arguments, inputs, and outputs.
-    - ``"full"``: not handled here (the caller should output the raw response
-      directly).
     """
     result: dict = {}
 
     if "scripts" in raw:
-        if detail_level == "extended":
-            result["scripts"] = filter_scripts(raw["scripts"])
-        else:
-            result["scripts"] = summarize_scripts(raw["scripts"])
+        result["scripts"] = summarize_scripts(raw["scripts"])
 
     if "playbooks" in raw:
-        if detail_level == "extended":
-            result["playbooks"] = filter_playbooks(raw["playbooks"])
-        else:
-            result["playbooks"] = summarize_playbooks(raw["playbooks"])
+        result["playbooks"] = summarize_playbooks(raw["playbooks"])
 
     if "commands" in raw:
-        if detail_level == "extended":
-            result["commands"] = filter_commands(raw["commands"])
-        else:
-            result["commands"] = summarize_commands(raw["commands"])
+        result["commands"] = summarize_commands(raw["commands"])
 
     return result

--- a/src/xsoar_cli/utilities/output.py
+++ b/src/xsoar_cli/utilities/output.py
@@ -1,0 +1,153 @@
+"""Output formatters for content list and describe commands.
+
+Supports three output formats:
+
+- **table** (default): human-readable aligned columns with section headers.
+- **json**: machine-readable JSON with 4-space indentation.
+- **plain**: tab-separated values, one item per line. No headers or
+  decoration, suitable for piping to grep/cut/awk.
+"""
+
+from __future__ import annotations
+
+import json
+
+OUTPUT_FORMATS = ("json", "table", "plain")
+
+
+def format_content_output(
+    data: dict,
+    *,
+    output_format: str,
+) -> str:
+    """Format the content summary for display.
+
+    *data* is the dict produced by ``filter_content()``, keyed by content
+    type (``scripts``, ``playbooks``, ``commands``). *output_format*
+    selects the presentation style.
+    """
+    if output_format == "json":
+        return json.dumps(data, indent=4)
+
+    formatter = _format_table if output_format == "table" else _format_plain
+
+    sections: list[str] = []
+    if "scripts" in data:
+        sections.append(formatter(data["scripts"], "scripts"))
+    if "playbooks" in data:
+        sections.append(formatter(data["playbooks"], "playbooks"))
+    if "commands" in data:
+        sections.append(formatter(data["commands"], "commands"))
+
+    return "\n\n".join(sections)
+
+
+# ---------------------------------------------------------------------------
+# Table format
+# ---------------------------------------------------------------------------
+
+
+def _format_table(items: list[dict], content_type: str) -> str:
+    if content_type == "scripts":
+        return _table_scripts(items)
+    if content_type == "playbooks":
+        return _table_playbooks(items)
+    return _table_commands(items)
+
+
+def _table_scripts(scripts: list[dict]) -> str:
+    header = f"Scripts ({len(scripts)})"
+    headers = ["ID", "Description"]
+    rows = [[s.get("id", ""), _oneline(s.get("comment", ""))] for s in scripts]
+    return f"{header}\n\n{_render_table(headers, rows, max_widths={1: 80})}"
+
+
+def _table_playbooks(playbooks: list[dict]) -> str:
+    header = f"Playbooks ({len(playbooks)})"
+    headers = ["ID", "Description"]
+    rows = [[p.get("id", ""), _oneline(p.get("comment", ""))] for p in playbooks]
+    return f"{header}\n\n{_render_table(headers, rows, max_widths={0: 50, 1: 80})}"
+
+
+def _table_commands(command_groups: list[dict]) -> str:
+    total = sum(len(g.get("commands", [])) for g in command_groups)
+    header = f"Commands ({total} commands from {len(command_groups)} integrations)"
+    headers = ["Command", "Description"]
+    rows = []
+    for group in command_groups:
+        for cmd in group.get("commands", []):
+            rows.append([cmd.get("name", ""), _oneline(cmd.get("description", ""))])
+    return f"{header}\n\n{_render_table(headers, rows, max_widths={1: 80})}"
+
+
+# ---------------------------------------------------------------------------
+# Plain format (tab-separated, no decoration)
+# ---------------------------------------------------------------------------
+
+
+def _format_plain(items: list[dict], content_type: str) -> str:
+    if content_type == "scripts":
+        return _plain_scripts(items)
+    if content_type == "playbooks":
+        return _plain_playbooks(items)
+    return _plain_commands(items)
+
+
+def _plain_scripts(scripts: list[dict]) -> str:
+    return "\n".join(f"{s.get('id', '')}\t{_oneline(s.get('comment', ''))}" for s in scripts)
+
+
+def _plain_playbooks(playbooks: list[dict]) -> str:
+    return "\n".join(f"{p.get('id', '')}\t{_oneline(p.get('comment', ''))}" for p in playbooks)
+
+
+def _plain_commands(command_groups: list[dict]) -> str:
+    lines: list[str] = []
+    for group in command_groups:
+        for cmd in group.get("commands", []):
+            lines.append(f"{cmd.get('name', '')}\t{_oneline(cmd.get('description', ''))}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _render_table(
+    headers: list[str],
+    rows: list[list[str]],
+    *,
+    max_widths: dict[int, int] | None = None,
+) -> str:
+    """Render headers and rows as an aligned table with a dashed separator.
+
+    *max_widths* maps column indices to maximum character widths. Cells
+    exceeding the limit are truncated with an ellipsis.
+    """
+    col_count = len(headers)
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i in range(min(col_count, len(row))):
+            widths[i] = max(widths[i], len(row[i]))
+
+    if max_widths:
+        for col, limit in max_widths.items():
+            if col < col_count:
+                widths[col] = min(widths[col], limit)
+
+    def _fit(text: str, width: int) -> str:
+        if len(text) <= width:
+            return text.ljust(width)
+        return text[: width - 3] + "..."
+
+    header_line = "  ".join(h.ljust(w) for h, w in zip(headers, widths))
+    separator = "  ".join("-" * w for w in widths)
+    data_lines = ["  ".join(_fit(row[i] if i < len(row) else "", widths[i]) for i in range(col_count)).rstrip() for row in rows]
+
+    return "\n".join([header_line.rstrip(), separator, *data_lines])
+
+
+def _oneline(text: str) -> str:
+    """Collapse a multi-line string into a single line."""
+    return " ".join(text.split())

--- a/src/xsoar_cli/utilities/output.py
+++ b/src/xsoar_cli/utilities/output.py
@@ -109,6 +109,120 @@ def _plain_commands(command_groups: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _oneline(text: str) -> str:
+    """Collapse a multi-line string into a single line."""
+    return " ".join(text.split())
+
+
+# ---------------------------------------------------------------------------
+# Describe (single-item vertical detail)
+# ---------------------------------------------------------------------------
+
+DESCRIBE_OUTPUT_FORMATS = ("table", "json")
+
+
+def format_describe(item_type: str, item: dict, *, output_format: str) -> str:
+    """Format a single content item for the ``content describe`` command.
+
+    *item* is the reduced dict produced by ``describe_item()``. *item_type*
+    is ``script``, ``playbook``, or ``command`` (singular). The ``table``
+    format is a vertical detail layout; ``json`` dumps the reduced dict.
+    """
+    if output_format == "json":
+        return json.dumps(item, indent=4)
+    if item_type == "script":
+        return _describe_script(item)
+    if item_type == "playbook":
+        return _describe_playbook(item)
+    if item_type == "command":
+        return _describe_command(item)
+    raise ValueError(f"Invalid value {item_type=}")
+
+
+def _describe_script(item: dict) -> str:
+    parts = [f"Script: {item.get('id', '')}"]
+    comment = item.get("comment", "").strip()
+    if comment:
+        parts.append(comment)
+    parts.append(_describe_section("Arguments", _argument_rows(item.get("arguments", []))))
+    return "\n\n".join(parts)
+
+
+def _describe_playbook(item: dict) -> str:
+    parts = [f"Playbook: {item.get('id', '')}"]
+    comment = item.get("comment", "").strip()
+    if comment:
+        parts.append(comment)
+    input_rows = [[inp.get("key", ""), _oneline(inp.get("description", ""))] for inp in item.get("inputs", [])]
+    parts.append(_describe_section("Inputs", input_rows))
+    parts.append(_describe_section("Outputs", _output_rows(item.get("outputs", []))))
+    return "\n\n".join(parts)
+
+
+def _describe_command(item: dict) -> str:
+    parts = [f"Command: {item.get('name', '')}", f"Brand: {item.get('brand', '')}"]
+    instance_rows = [[inst.get("name", ""), inst.get("state", "")] for inst in item.get("instances", [])]
+    parts.append(_describe_section("Instances", instance_rows))
+    description = item.get("description", "").strip()
+    if description:
+        parts.append(description)
+    parts.append(_describe_section("Arguments", _argument_rows(item.get("arguments", []))))
+    parts.append(_describe_section("Outputs", _output_rows(item.get("outputs", []))))
+    return "\n\n".join(parts)
+
+
+def _argument_rows(arguments: list[dict]) -> list[list[str]]:
+    return [
+        [
+            arg.get("name", ""),
+            "(required)" if arg.get("required") else "",
+            _oneline(arg.get("description", "")),
+        ]
+        for arg in arguments
+    ]
+
+
+def _output_rows(outputs: list[dict]) -> list[list[str]]:
+    return [
+        [
+            out.get("contextPath", ""),
+            out.get("type", "") or "",
+            _oneline(out.get("description", "")),
+        ]
+        for out in outputs
+    ]
+
+
+def _describe_section(label: str, rows: list[list[str]]) -> str:
+    """Render a labelled section with aligned, indented columns.
+
+    When *rows* is empty the section body is ``(none)``.
+    """
+    return f"{label}:\n{_aligned_columns(rows)}"
+
+
+def _aligned_columns(rows: list[list[str]], *, indent: str = "  ") -> str:
+    """Align rows into columns, indented, with no header. Empty -> ``(none)``."""
+    if not rows:
+        return f"{indent}(none)"
+
+    col_count = max(len(row) for row in rows)
+    widths = [0] * col_count
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    lines = []
+    for row in rows:
+        cells = []
+        for i in range(col_count):
+            cell = row[i] if i < len(row) else ""
+            # Pad every column except the last so trailing text is not padded.
+            cells.append(cell.ljust(widths[i]) if i < col_count - 1 else cell)
+        lines.append((indent + "  ".join(cells)).rstrip())
+    return "\n".join(lines)
+
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
@@ -146,8 +260,3 @@ def _render_table(
     data_lines = ["  ".join(_fit(row[i] if i < len(row) else "", widths[i]) for i in range(col_count)).rstrip() for row in rows]
 
     return "\n".join([header_line.rstrip(), separator, *data_lines])
-
-
-def _oneline(text: str) -> str:
-    """Collapse a multi-line string into a single line."""
-    return " ".join(text.split())

--- a/src/xsoar_cli/xsoar_client/content.py
+++ b/src/xsoar_cli/xsoar_client/content.py
@@ -204,3 +204,66 @@ class Content:
         if item_type == "all":
             return {"playbooks": self._list_playbooks(), "scripts": self._list_scripts(), "commands": self._list_commands()}
         raise ValueError(f"ERROR: list command received invalid argument {item_type=}")
+
+    def _describe_script(self, name: str) -> dict | None:
+        needle = name.lower()
+        for script in self._list_scripts():
+            if script.get("id", "").lower() == needle:
+                return script
+        return None
+
+    def _describe_playbook(self, name: str) -> dict | None:
+        needle = name.lower()
+        for playbook in self._list_playbooks():
+            if playbook.get("id", "").lower() == needle or playbook.get("name", "").lower() == needle:
+                return playbook
+        return None
+
+    def _describe_command(self, name: str) -> dict | None:
+        """Find a command by name and gather its brand and instances.
+
+        Returns a dict with the matching command, its brand, and every
+        instance of that brand (name and state), or None when no command
+        matches. The command definition is identical across instances of
+        the same brand, so the first match supplies the command detail.
+        """
+        needle = name.lower()
+        instances = self._list_commands()
+        matched_command: dict | None = None
+        brand = ""
+        for instance in instances:
+            for command in instance.get("commands") or []:
+                if command.get("name", "").lower() == needle:
+                    matched_command = command
+                    brand = instance.get("brand", "")
+                    break
+            if matched_command is not None:
+                break
+
+        if matched_command is None:
+            return None
+
+        brand_instances = [
+            {"name": instance.get("name", ""), "state": instance.get("state", "")}
+            for instance in instances
+            if instance.get("brand", "") == brand
+        ]
+        return {"brand": brand, "instances": brand_instances, "command": matched_command}
+
+    def describe(self, item_type: str, name: str) -> dict | None:
+        """Return the raw record for a single content item, or None if not found.
+
+        *item_type* must be ``script``, ``playbook``, or ``command`` (singular).
+        Scripts match on ``id``, playbooks match on ``id`` or ``name``, and
+        commands match on the command name. All matches are case-insensitive.
+
+        For commands, the result also carries the integration ``brand`` and the
+        list of ``instances`` (name and state) configured for that brand.
+        """
+        if item_type == "script":
+            return self._describe_script(name)
+        if item_type == "playbook":
+            return self._describe_playbook(name)
+        if item_type == "command":
+            return self._describe_command(name)
+        raise ValueError(f"Invalid value {item_type=}")

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -130,6 +130,34 @@ def mock_content_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # no
 
 
 @pytest.fixture
+def mock_content_list_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # noqa: ANN001
+    """Mock environment for the ``content list`` command.
+
+    Patches connectivity and ``Content.list``. The ``list`` mock is exposed
+    on the yielded namespace so tests can set its return value to the raw
+    API shape for the requested content type.
+
+    Yields a ``SimpleNamespace`` with attributes:
+
+    * ``config`` -- the config file mock
+    * ``connectivity`` -- the ``Client.test_connectivity`` mock
+    * ``list`` -- the ``Content.list`` mock
+    """
+    import types as _types
+
+    with (
+        patch("xsoar_cli.xsoar_client.client.Client.test_connectivity", return_value=True) as mock_conn,
+        patch("xsoar_cli.xsoar_client.content.Content.list") as mock_list,
+    ):
+        ns = _types.SimpleNamespace(
+            config=mock_config_file,
+            connectivity=mock_conn,
+            list=mock_list,
+        )
+        yield ns
+
+
+@pytest.fixture
 def mock_plugin_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # noqa: ANN001
     """Mock environment for ``plugins`` CLI subcommands.
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -158,6 +158,34 @@ def mock_content_list_env(mock_config_file) -> Iterator[types.SimpleNamespace]: 
 
 
 @pytest.fixture
+def mock_content_describe_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # noqa: ANN001
+    """Mock environment for the ``content describe`` command.
+
+    Patches connectivity and ``Content.describe``. The ``describe`` mock is
+    exposed on the yielded namespace so tests can set its return value to the
+    raw record shape (or None for the not-found case).
+
+    Yields a ``SimpleNamespace`` with attributes:
+
+    * ``config`` -- the config file mock
+    * ``connectivity`` -- the ``Client.test_connectivity`` mock
+    * ``describe`` -- the ``Content.describe`` mock
+    """
+    import types as _types
+
+    with (
+        patch("xsoar_cli.xsoar_client.client.Client.test_connectivity", return_value=True) as mock_conn,
+        patch("xsoar_cli.xsoar_client.content.Content.describe") as mock_describe,
+    ):
+        ns = _types.SimpleNamespace(
+            config=mock_config_file,
+            connectivity=mock_conn,
+            describe=mock_describe,
+        )
+        yield ns
+
+
+@pytest.fixture
 def mock_plugin_env(mock_config_file) -> Iterator[types.SimpleNamespace]:  # noqa: ANN001
     """Mock environment for ``plugins`` CLI subcommands.
 

--- a/tests/cli/test_content.py
+++ b/tests/cli/test_content.py
@@ -10,6 +10,75 @@ if TYPE_CHECKING:
 PLAYBOOK_YAML = "id: test-playbook\nname: Test Playbook\ncontentitemexportablefields:\n  contentitemfields:\n    packID: MyPack\n"
 PLAYBOOK_YAML_NO_PACK = "id: test-playbook\nname: Test Playbook\n"
 
+_RAW_COMMANDS = [
+    {
+        "brand": "SlackV3",
+        "name": "SlackV3_instance",
+        "commands": [
+            {"name": "slack-send-file", "description": "Upload a file to Slack.", "arguments": [], "outputs": []},
+            {"name": "mirror-investigation", "description": "Mirror an investigation.", "arguments": [], "outputs": []},
+        ],
+    },
+    {
+        "brand": "Whois",
+        "name": "Whois_instance",
+        "commands": [
+            {"name": "whois", "description": "Look up domain registration.", "arguments": [], "outputs": []},
+        ],
+    },
+]
+
+_RAW_SCRIPTS = [
+    {"id": "SlackSendMessage", "comment": "Send a message to a channel."},
+    {"id": "PrintToWarRoom", "comment": "Prints text to the war room."},
+]
+
+
+class TestContentList:
+    """Tests for ``content list``."""
+
+    def test_default_output_is_table(self, invoke: InvokeHelper, mock_content_list_env) -> None:
+        mock_content_list_env.list.return_value = _RAW_COMMANDS
+        result = invoke(["content", "list", "--type", "commands"])
+        assert result.exit_code == 0
+        assert "Command" in result.output
+        assert "Description" in result.output
+        assert "slack-send-file" in result.output
+
+    def test_json_output(self, invoke: InvokeHelper, mock_content_list_env) -> None:
+        mock_content_list_env.list.return_value = _RAW_SCRIPTS
+        result = invoke(["content", "list", "--type", "scripts", "--output-format", "json"])
+        assert result.exit_code == 0
+        assert '"id": "SlackSendMessage"' in result.output
+
+    def test_search_filters_commands(self, invoke: InvokeHelper, mock_content_list_env) -> None:
+        mock_content_list_env.list.return_value = _RAW_COMMANDS
+        result = invoke(["content", "list", "--type", "commands", "--search", "slack", "--output-format", "plain"])
+        assert result.exit_code == 0
+        assert "slack-send-file" in result.output
+        assert "mirror-investigation" not in result.output
+        assert "whois" not in result.output
+
+    def test_search_is_case_insensitive(self, invoke: InvokeHelper, mock_content_list_env) -> None:
+        mock_content_list_env.list.return_value = _RAW_COMMANDS
+        result = invoke(["content", "list", "--type", "commands", "--search", "SLACK", "--output-format", "plain"])
+        assert result.exit_code == 0
+        assert "slack-send-file" in result.output
+
+    def test_no_search_returns_all(self, invoke: InvokeHelper, mock_content_list_env) -> None:
+        mock_content_list_env.list.return_value = _RAW_COMMANDS
+        result = invoke(["content", "list", "--type", "commands", "--output-format", "plain"])
+        assert result.exit_code == 0
+        assert "slack-send-file" in result.output
+        assert "mirror-investigation" in result.output
+        assert "whois" in result.output
+
+    def test_search_no_matches_shows_message(self, invoke: InvokeHelper, mock_content_list_env) -> None:
+        mock_content_list_env.list.return_value = _RAW_COMMANDS
+        result = invoke(["content", "list", "--type", "commands", "--search", "zzzznomatch"])
+        assert result.exit_code == 0
+        assert "No content matching 'zzzznomatch' found" in result.output
+
 
 class TestContentDownloadPlaybookCommand:
     """Tests for ``content download --type playbook``."""

--- a/tests/cli/test_content.py
+++ b/tests/cli/test_content.py
@@ -80,6 +80,73 @@ class TestContentList:
         assert "No content matching 'zzzznomatch' found" in result.output
 
 
+_DESCRIBE_RAW_SCRIPT = {
+    "id": "MyScript",
+    "comment": "Does a thing.",
+    "arguments": [{"name": "value", "required": True, "deprecated": False, "description": "The value"}],
+}
+
+_DESCRIBE_RAW_COMMAND = {
+    "brand": "ServiceNow v2",
+    "instances": [
+        {"name": "ServiceNow_v2_DNB", "state": "active"},
+        {"name": "ServiceNow_Pentest_RITM", "state": "disabled"},
+    ],
+    "command": {
+        "name": "servicenow-get-record",
+        "description": "Get a record.",
+        "arguments": [{"name": "table", "required": True, "deprecated": False, "description": "The table"}],
+        "outputs": [{"contextPath": "ServiceNow.Record.ID", "description": "Record ID", "type": "string"}],
+    },
+}
+
+
+class TestContentDescribe:
+    """Tests for ``content describe``."""
+
+    def test_script_table_output(self, invoke: InvokeHelper, mock_content_describe_env) -> None:
+        mock_content_describe_env.describe.return_value = _DESCRIBE_RAW_SCRIPT
+        result = invoke(["content", "describe", "--type", "script", "MyScript"])
+        assert result.exit_code == 0
+        assert "Script: MyScript" in result.output
+        assert "Does a thing." in result.output
+        assert "value" in result.output
+        mock_content_describe_env.describe.assert_called_once_with("script", "MyScript")
+
+    def test_command_table_output(self, invoke: InvokeHelper, mock_content_describe_env) -> None:
+        mock_content_describe_env.describe.return_value = _DESCRIBE_RAW_COMMAND
+        result = invoke(["content", "describe", "--type", "command", "servicenow-get-record"])
+        assert result.exit_code == 0
+        assert "Command: servicenow-get-record" in result.output
+        assert "Brand: ServiceNow v2" in result.output
+        assert "Instances:" in result.output
+        assert "ServiceNow_v2_DNB" in result.output
+        assert "disabled" in result.output
+
+    def test_json_output(self, invoke: InvokeHelper, mock_content_describe_env) -> None:
+        mock_content_describe_env.describe.return_value = _DESCRIBE_RAW_SCRIPT
+        result = invoke(["content", "describe", "--type", "script", "MyScript", "--output-format", "json"])
+        assert result.exit_code == 0
+        assert '"id": "MyScript"' in result.output
+        assert '"arguments"' in result.output
+
+    def test_not_found_exits_nonzero(self, invoke: InvokeHelper, mock_content_describe_env) -> None:
+        mock_content_describe_env.describe.return_value = None
+        result = invoke(["content", "describe", "--type", "script", "Nonexistent"])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+        assert "Nonexistent" in result.output
+
+    def test_missing_type(self, invoke: InvokeHelper, mock_content_describe_env) -> None:
+        result = invoke(["content", "describe", "SomeName"])
+        assert result.exit_code != 0
+        assert "Missing option '--type'" in result.output
+
+    def test_plain_format_not_accepted(self, invoke: InvokeHelper, mock_content_describe_env) -> None:
+        result = invoke(["content", "describe", "--type", "script", "MyScript", "--output-format", "plain"])
+        assert result.exit_code != 0
+
+
 class TestContentDownloadPlaybookCommand:
     """Tests for ``content download --type playbook``."""
 

--- a/tests/unit/test_content_domain.py
+++ b/tests/unit/test_content_domain.py
@@ -704,3 +704,130 @@ class TestContentList:
         content = Content(mock_client)
         with pytest.raises(ValueError, match="invalid argument"):
             content.list("invalid")
+
+
+# ===========================================================================
+# Content.describe
+# ===========================================================================
+
+
+_DESCRIBE_SCRIPTS = {
+    "scripts": [
+        {"id": "AddDNBHostIndicatorToCase", "comment": "Creates a DNB Host indicator.", "arguments": []},
+        {"id": "Print", "comment": "Prints text.", "arguments": []},
+    ],
+}
+
+_DESCRIBE_PLAYBOOKS = {
+    "playbooks": [
+        {"id": "02557104-uuid", "name": "test_temp", "comment": "A temp playbook.", "inputs": [], "outputs": []},
+        {"id": "KS_Escalated", "name": "KS_Escalated", "comment": "Escalation playbook.", "inputs": [], "outputs": []},
+    ],
+}
+
+_DESCRIBE_COMMANDS = [
+    {
+        "brand": "ServiceNow v2",
+        "name": "ServiceNow_v2_DNB",
+        "state": "active",
+        "commands": [
+            {"name": "servicenow-get-record", "description": "Get a record.", "arguments": [], "outputs": []},
+        ],
+    },
+    {
+        "brand": "ServiceNow v2",
+        "name": "ServiceNow_Pentest_RITM",
+        "state": "disabled",
+        "commands": [
+            {"name": "servicenow-get-record", "description": "Get a record.", "arguments": [], "outputs": []},
+        ],
+    },
+    {
+        "brand": "Whois",
+        "name": "Whois_instance",
+        "state": "active",
+        "commands": [
+            {"name": "whois", "description": "Look up domain registration.", "arguments": [], "outputs": []},
+        ],
+    },
+]
+
+
+class TestDescribe:
+    """Tests for the Content.describe method."""
+
+    def _client_returning(self, json_value: object) -> MagicMock:
+        mock_client = MagicMock()
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = json_value
+        mock_client.make_request.return_value = response
+        return mock_client
+
+    def test_script_found(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_SCRIPTS))
+        result = content.describe("script", "AddDNBHostIndicatorToCase")
+        assert result == _DESCRIBE_SCRIPTS["scripts"][0]
+
+    def test_script_case_insensitive(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_SCRIPTS))
+        result = content.describe("script", "adddnbhostindicatortocase")
+        assert result["id"] == "AddDNBHostIndicatorToCase"
+
+    def test_script_not_found(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_SCRIPTS))
+        assert content.describe("script", "Nonexistent") is None
+
+    def test_playbook_found_by_name(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_PLAYBOOKS))
+        result = content.describe("playbook", "test_temp")
+        assert result["id"] == "02557104-uuid"
+
+    def test_playbook_found_by_id(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_PLAYBOOKS))
+        result = content.describe("playbook", "02557104-uuid")
+        assert result["name"] == "test_temp"
+
+    def test_playbook_case_insensitive(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_PLAYBOOKS))
+        result = content.describe("playbook", "TEST_TEMP")
+        assert result["id"] == "02557104-uuid"
+
+    def test_playbook_not_found(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_PLAYBOOKS))
+        assert content.describe("playbook", "Nonexistent") is None
+
+    def test_command_found(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_COMMANDS))
+        result = content.describe("command", "servicenow-get-record")
+        assert result["brand"] == "ServiceNow v2"
+        assert result["command"]["name"] == "servicenow-get-record"
+        assert result["command"]["description"] == "Get a record."
+
+    def test_command_collects_all_brand_instances(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_COMMANDS))
+        result = content.describe("command", "servicenow-get-record")
+        assert result["instances"] == [
+            {"name": "ServiceNow_v2_DNB", "state": "active"},
+            {"name": "ServiceNow_Pentest_RITM", "state": "disabled"},
+        ]
+
+    def test_command_only_includes_matching_brand_instances(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_COMMANDS))
+        result = content.describe("command", "whois")
+        assert result["brand"] == "Whois"
+        assert result["instances"] == [{"name": "Whois_instance", "state": "active"}]
+
+    def test_command_case_insensitive(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_COMMANDS))
+        result = content.describe("command", "SERVICENOW-GET-RECORD")
+        assert result["command"]["name"] == "servicenow-get-record"
+
+    def test_command_not_found(self) -> None:
+        content = Content(self._client_returning(_DESCRIBE_COMMANDS))
+        assert content.describe("command", "nonexistent-command") is None
+
+    def test_invalid_type_raises(self) -> None:
+        content = Content(MagicMock())
+        with pytest.raises(ValueError, match="Invalid value"):
+            content.describe("widget", "anything")

--- a/tests/unit/test_content_filters.py
+++ b/tests/unit/test_content_filters.py
@@ -56,6 +56,7 @@ _PLAYBOOKS = [
     {
         "id": "22a1b2c3-d4e5-6f78-9a0b-c1d2e3f4a5b6",
         "name": "Phishing Investigation - Generic v2",
+        "comment": "Investigate phishing emails using multiple integrations.",
         "inputs": [
             {"key": "EmailFrom", "value": {}, "description": "The sender email address"},
             {"key": "EmailSubject", "value": {}, "description": "The email subject line"},
@@ -71,6 +72,7 @@ _PLAYBOOKS = [
     {
         "id": "Malware_Investigation",
         "name": "Malware Investigation",
+        "comment": "",
         "inputs": [],
         "outputs": None,
         "tasks": {},
@@ -80,6 +82,7 @@ _PLAYBOOKS = [
     {
         "id": "aabbccdd-1122-3344-5566-778899aabbcc",
         "name": "Access Investigation - Generic",
+        "comment": "Investigate access-related incidents.",
         "inputs": None,
         "outputs": [],
         "tasks": {},
@@ -194,9 +197,9 @@ class TestSummarizePlaybooks:
     def test_typical_input(self) -> None:
         result = summarize_playbooks(_PLAYBOOKS)
         assert result == [
-            {"id": "22a1b2c3-d4e5-6f78-9a0b-c1d2e3f4a5b6", "name": "Phishing Investigation - Generic v2"},
-            {"id": "Malware_Investigation", "name": "Malware Investigation"},
-            {"id": "aabbccdd-1122-3344-5566-778899aabbcc", "name": "Access Investigation - Generic"},
+            {"id": "22a1b2c3-d4e5-6f78-9a0b-c1d2e3f4a5b6", "comment": "Investigate phishing emails using multiple integrations."},
+            {"id": "Malware_Investigation", "comment": ""},
+            {"id": "aabbccdd-1122-3344-5566-778899aabbcc", "comment": "Investigate access-related incidents."},
         ]
 
     def test_empty_list(self) -> None:
@@ -204,7 +207,7 @@ class TestSummarizePlaybooks:
 
     def test_missing_fields_use_defaults(self) -> None:
         result = summarize_playbooks([{}])
-        assert result == [{"id": "", "name": ""}]
+        assert result == [{"id": "", "comment": ""}]
 
 
 class TestFilterPlaybooks:
@@ -214,7 +217,7 @@ class TestFilterPlaybooks:
 
         first = result[0]
         assert first["id"] == "22a1b2c3-d4e5-6f78-9a0b-c1d2e3f4a5b6"
-        assert first["name"] == "Phishing Investigation - Generic v2"
+        assert first["comment"] == "Investigate phishing emails using multiple integrations."
         assert len(first["inputs"]) == 2
         assert first["inputs"][0] == {"key": "EmailFrom", "description": "The sender email address"}
         assert len(first["outputs"]) == 2
@@ -269,8 +272,18 @@ class TestSummarizeCommands:
     def test_typical_input(self) -> None:
         result = summarize_commands(_COMMAND_INSTANCES)
         assert len(result) == 2
-        assert result[0] == {"brand": "EWS v2", "commands": ["ews-search-mailbox"]}
-        assert result[1] == {"brand": "VirusTotal", "commands": ["vt-file-scan"]}
+        assert result[0] == {
+            "brand": "EWS v2",
+            "commands": [
+                {"name": "ews-search-mailbox", "description": "Search for items in a mailbox."},
+            ],
+        }
+        assert result[1] == {
+            "brand": "VirusTotal",
+            "commands": [
+                {"name": "vt-file-scan", "description": "Scan a file with VirusTotal."},
+            ],
+        }
 
     def test_empty_list(self) -> None:
         assert summarize_commands([]) == []
@@ -316,7 +329,7 @@ class TestFilterCommands:
 class TestFilterContent:
     def test_scripts_summary(self) -> None:
         raw = {"scripts": _SCRIPTS}
-        result = filter_content(raw, detail_level="short")
+        result = filter_content(raw)
         assert "scripts" in result
         assert len(result["scripts"]) == 3
         assert result["scripts"][0] == {
@@ -324,39 +337,20 @@ class TestFilterContent:
             "comment": "Set a value in context under the key you entered.",
         }
 
-    def test_scripts_detail(self) -> None:
-        raw = {"scripts": _SCRIPTS}
-        result = filter_content(raw, detail_level="extended")
-        assert "scripts" in result
-        assert "arguments" in result["scripts"][0]
-
     def test_playbooks_summary(self) -> None:
         raw = {"playbooks": _PLAYBOOKS}
-        result = filter_content(raw, detail_level="short")
+        result = filter_content(raw)
         assert "playbooks" in result
         assert result["playbooks"][0] == {
             "id": "22a1b2c3-d4e5-6f78-9a0b-c1d2e3f4a5b6",
-            "name": "Phishing Investigation - Generic v2",
+            "comment": "Investigate phishing emails using multiple integrations.",
         }
-
-    def test_playbooks_detail(self) -> None:
-        raw = {"playbooks": _PLAYBOOKS}
-        result = filter_content(raw, detail_level="extended")
-        assert "playbooks" in result
-        assert "inputs" in result["playbooks"][0]
-        assert "outputs" in result["playbooks"][0]
 
     def test_commands_summary(self) -> None:
         raw = {"commands": _COMMAND_INSTANCES}
-        result = filter_content(raw, detail_level="short")
+        result = filter_content(raw)
         assert "commands" in result
         assert len(result["commands"]) == 2
-
-    def test_commands_detail(self) -> None:
-        raw = {"commands": _COMMAND_INSTANCES}
-        result = filter_content(raw, detail_level="extended")
-        assert "commands" in result
-        assert "arguments" in result["commands"][0]["commands"][0]
 
     def test_all_types_combined(self) -> None:
         raw = {
@@ -364,7 +358,7 @@ class TestFilterContent:
             "playbooks": _PLAYBOOKS,
             "commands": _COMMAND_INSTANCES,
         }
-        result = filter_content(raw, detail_level="short")
+        result = filter_content(raw)
         assert set(result.keys()) == {"scripts", "playbooks", "commands"}
 
     def test_empty_dict(self) -> None:

--- a/tests/unit/test_content_filters.py
+++ b/tests/unit/test_content_filters.py
@@ -14,6 +14,7 @@ from xsoar_cli.utilities.content import (
     filter_playbooks,
     filter_scripts,
     format_detached_summary,
+    search_content,
     summarize_commands,
     summarize_playbooks,
     summarize_scripts,
@@ -367,6 +368,124 @@ class TestFilterContent:
     def test_unknown_keys_ignored(self) -> None:
         raw = {"unknown": [{"id": "1"}]}
         assert filter_content(raw) == {}
+
+
+# ===========================================================================
+# Search (search_content)
+# ===========================================================================
+
+
+# Summary-shaped data, as produced by ``filter_content``.
+_SUMMARY = {
+    "scripts": [
+        {"id": "SlackSendMessage", "comment": "Send a message to a channel."},
+        {"id": "PrintToWarRoom", "comment": "Prints text to the war room."},
+        {"id": "AccountEnrichment", "comment": "Enrich an account using Slack lookups."},
+    ],
+    "playbooks": [
+        {"id": "abc-123", "comment": "Slack notification playbook."},
+        {"id": "Phishing Response", "comment": "Investigate phishing emails."},
+    ],
+    "commands": [
+        {
+            "brand": "SlackV3",
+            "commands": [
+                {"name": "slack-send-file", "description": "Upload a file to Slack."},
+                {"name": "mirror-investigation", "description": "Mirror an investigation."},
+            ],
+        },
+        {
+            "brand": "Whois",
+            "commands": [
+                {"name": "whois", "description": "Look up domain registration."},
+                {"name": "ip", "description": "Look up IP information."},
+            ],
+        },
+    ],
+}
+
+
+class TestSearchContent:
+    def test_empty_term_returns_everything(self) -> None:
+        assert search_content(_SUMMARY, "") == _SUMMARY
+
+    def test_matches_script_by_id(self) -> None:
+        result = search_content(_SUMMARY, "PrintToWarRoom")
+        assert result["scripts"] == [{"id": "PrintToWarRoom", "comment": "Prints text to the war room."}]
+        assert "playbooks" not in result
+        assert "commands" not in result
+
+    def test_matches_script_by_comment(self) -> None:
+        result = search_content(_SUMMARY, "enrich an account")
+        ids = [s["id"] for s in result["scripts"]]
+        assert ids == ["AccountEnrichment"]
+
+    def test_case_insensitive(self) -> None:
+        lower = search_content(_SUMMARY, "slack")
+        upper = search_content(_SUMMARY, "SLACK")
+        assert lower == upper
+
+    def test_matches_scripts_across_id_and_comment(self) -> None:
+        result = search_content(_SUMMARY, "slack")
+        ids = [s["id"] for s in result["scripts"]]
+        # SlackSendMessage matches on id, AccountEnrichment on comment.
+        assert ids == ["SlackSendMessage", "AccountEnrichment"]
+
+    def test_matches_playbook_by_id_and_comment(self) -> None:
+        result = search_content(_SUMMARY, "slack")
+        ids = [p["id"] for p in result["playbooks"]]
+        assert ids == ["abc-123"]
+
+    def test_commands_keep_only_matching_within_brand(self) -> None:
+        result = search_content(_SUMMARY, "slack")
+        assert result["commands"] == [
+            {
+                "brand": "SlackV3",
+                "commands": [{"name": "slack-send-file", "description": "Upload a file to Slack."}],
+            }
+        ]
+
+    def test_commands_match_by_description(self) -> None:
+        result = search_content(_SUMMARY, "registration")
+        assert result["commands"] == [
+            {
+                "brand": "Whois",
+                "commands": [{"name": "whois", "description": "Look up domain registration."}],
+            }
+        ]
+
+    def test_brand_with_no_matching_commands_dropped(self) -> None:
+        result = search_content(_SUMMARY, "mirror")
+        brands = [g["brand"] for g in result["commands"]]
+        assert brands == ["SlackV3"]
+
+    def test_empty_type_dropped(self) -> None:
+        result = search_content(_SUMMARY, "mirror")
+        # Only a command matches; scripts and playbooks keys are omitted.
+        assert set(result.keys()) == {"commands"}
+
+    def test_no_matches_returns_empty_dict(self) -> None:
+        assert search_content(_SUMMARY, "zzzznomatch") == {}
+
+    def test_matches_by_name_field_when_present(self) -> None:
+        summary = {"scripts": [{"id": "uuid-1", "name": "Human Readable", "comment": ""}]}
+        result = search_content(summary, "human readable")
+        assert result["scripts"] == [{"id": "uuid-1", "name": "Human Readable", "comment": ""}]
+
+    def test_does_not_match_brand_name(self) -> None:
+        # Searching the brand alone should not pull in commands that do not
+        # match on name or description.
+        result = search_content(_SUMMARY, "whois")
+        # Only the 'whois' command matches by name; 'ip' does not.
+        assert result["commands"] == [
+            {
+                "brand": "Whois",
+                "commands": [{"name": "whois", "description": "Look up domain registration."}],
+            }
+        ]
+
+    def test_empty_input_dict(self) -> None:
+        assert search_content({}, "slack") == {}
 
 
 class TestFormatDetachedSummary:

--- a/tests/unit/test_content_filters.py
+++ b/tests/unit/test_content_filters.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from xsoar_cli.utilities.content import (
     _group_commands_by_brand,
+    describe_item,
     filter_commands,
     filter_content,
     filter_playbooks,
@@ -486,6 +487,83 @@ class TestSearchContent:
 
     def test_empty_input_dict(self) -> None:
         assert search_content({}, "slack") == {}
+
+
+# ===========================================================================
+# Describe reduction (describe_item)
+# ===========================================================================
+
+
+class TestDescribeItem:
+    def test_script(self) -> None:
+        raw = {
+            "id": "MyScript",
+            "comment": "Does a thing.",
+            "arguments": [
+                {"name": "value", "required": True, "deprecated": False, "description": "The value"},
+            ],
+            "type": "python3",
+        }
+        result = describe_item("script", raw)
+        assert result == {
+            "id": "MyScript",
+            "comment": "Does a thing.",
+            "arguments": [{"name": "value", "required": True, "deprecated": False, "description": "The value"}],
+        }
+
+    def test_playbook(self) -> None:
+        raw = {
+            "id": "uuid-1",
+            "name": "My Playbook",
+            "comment": "Investigates things.",
+            "inputs": [{"key": "Target", "value": {}, "description": "The target"}],
+            "outputs": [{"contextPath": "Result.Verdict", "description": "The verdict", "type": "string"}],
+            "tasks": {"0": {"id": "0"}},
+        }
+        result = describe_item("playbook", raw)
+        assert result == {
+            "id": "uuid-1",
+            "comment": "Investigates things.",
+            "inputs": [{"key": "Target", "description": "The target"}],
+            "outputs": [{"contextPath": "Result.Verdict", "description": "The verdict", "type": "string"}],
+        }
+
+    def test_command(self) -> None:
+        raw = {
+            "brand": "ServiceNow v2",
+            "instances": [
+                {"name": "SN_DNB", "state": "active"},
+                {"name": "SN_Pentest", "state": "disabled"},
+            ],
+            "command": {
+                "name": "servicenow-get-record",
+                "description": "Get a record.",
+                "arguments": [
+                    {"name": "table", "required": True, "deprecated": False, "description": "The table"},
+                ],
+                "outputs": [
+                    {"contextPath": "ServiceNow.Record.ID", "description": "Record ID", "type": "string"},
+                ],
+            },
+        }
+        result = describe_item("command", raw)
+        assert result == {
+            "name": "servicenow-get-record",
+            "brand": "ServiceNow v2",
+            "instances": [
+                {"name": "SN_DNB", "state": "active"},
+                {"name": "SN_Pentest", "state": "disabled"},
+            ],
+            "description": "Get a record.",
+            "arguments": [{"name": "table", "required": True, "deprecated": False, "description": "The table"}],
+            "outputs": [{"contextPath": "ServiceNow.Record.ID", "description": "Record ID", "type": "string"}],
+        }
+
+    def test_invalid_type_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid"):
+            describe_item("widget", {})
 
 
 class TestFormatDetachedSummary:

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,0 +1,130 @@
+"""Unit tests for output formatters (``xsoar_cli.utilities.output``).
+
+These cover the ``format_describe`` vertical detail layout used by the
+``content describe`` command. The pure list/summary formatters are exercised
+through the CLI integration tests.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xsoar_cli.utilities.output import format_describe
+
+_SCRIPT = {
+    "id": "MyScript",
+    "comment": "Does a thing.",
+    "arguments": [
+        {"name": "value", "required": True, "deprecated": False, "description": "The value to use"},
+        {"name": "mode", "required": False, "deprecated": False, "description": "Optional mode"},
+    ],
+}
+
+_PLAYBOOK = {
+    "id": "uuid-1",
+    "comment": "Investigates things.",
+    "inputs": [{"key": "Target", "description": "The target"}],
+    "outputs": [{"contextPath": "Result.Verdict", "description": "The verdict", "type": "string"}],
+}
+
+_COMMAND = {
+    "name": "servicenow-get-record",
+    "brand": "ServiceNow v2",
+    "instances": [
+        {"name": "ServiceNow_v2_DNB", "state": "active"},
+        {"name": "ServiceNow_Pentest_RITM", "state": "disabled"},
+    ],
+    "description": "Get a record from a table.",
+    "arguments": [
+        {"name": "table", "required": True, "deprecated": False, "description": "The table name"},
+    ],
+    "outputs": [
+        {"contextPath": "ServiceNow.Record.ID", "description": "The record system ID", "type": "string"},
+    ],
+}
+
+
+class TestFormatDescribeJSON:
+    def test_script_json_roundtrips(self) -> None:
+        out = format_describe("script", _SCRIPT, output_format="json")
+        assert json.loads(out) == _SCRIPT
+
+    def test_command_json_roundtrips(self) -> None:
+        out = format_describe("command", _COMMAND, output_format="json")
+        assert json.loads(out) == _COMMAND
+
+
+class TestFormatDescribeScript:
+    def test_header_and_description(self) -> None:
+        out = format_describe("script", _SCRIPT, output_format="table")
+        assert "Script: MyScript" in out
+        assert "Does a thing." in out
+
+    def test_arguments_listed(self) -> None:
+        out = format_describe("script", _SCRIPT, output_format="table")
+        assert "Arguments:" in out
+        assert "value" in out
+        assert "(required)" in out
+        assert "The value to use" in out
+        assert "mode" in out
+
+    def test_no_arguments_shows_none(self) -> None:
+        script = {"id": "Bare", "comment": "No args.", "arguments": []}
+        out = format_describe("script", script, output_format="table")
+        assert "Arguments:" in out
+        assert "(none)" in out
+
+    def test_empty_comment_omitted(self) -> None:
+        script = {"id": "Bare", "comment": "", "arguments": []}
+        out = format_describe("script", script, output_format="table")
+        assert out.startswith("Script: Bare")
+
+
+class TestFormatDescribePlaybook:
+    def test_header_and_sections(self) -> None:
+        out = format_describe("playbook", _PLAYBOOK, output_format="table")
+        assert "Playbook: uuid-1" in out
+        assert "Investigates things." in out
+        assert "Inputs:" in out
+        assert "Target" in out
+        assert "Outputs:" in out
+        assert "Result.Verdict" in out
+        assert "string" in out
+
+    def test_empty_inputs_and_outputs_show_none(self) -> None:
+        playbook = {"id": "pb", "comment": "c", "inputs": [], "outputs": []}
+        out = format_describe("playbook", playbook, output_format="table")
+        assert out.count("(none)") == 2
+
+
+class TestFormatDescribeCommand:
+    def test_header_brand_and_sections(self) -> None:
+        out = format_describe("command", _COMMAND, output_format="table")
+        assert "Command: servicenow-get-record" in out
+        assert "Brand: ServiceNow v2" in out
+        assert "Get a record from a table." in out
+        assert "Arguments:" in out
+        assert "table" in out
+        assert "Outputs:" in out
+        assert "ServiceNow.Record.ID" in out
+
+    def test_instances_section_lists_all_with_state(self) -> None:
+        out = format_describe("command", _COMMAND, output_format="table")
+        assert "Instances:" in out
+        assert "ServiceNow_v2_DNB" in out
+        assert "active" in out
+        assert "ServiceNow_Pentest_RITM" in out
+        assert "disabled" in out
+
+    def test_brand_on_its_own_line(self) -> None:
+        out = format_describe("command", _COMMAND, output_format="table")
+        brand_lines = [line for line in out.splitlines() if line.startswith("Brand:")]
+        assert brand_lines == ["Brand: ServiceNow v2"]
+
+
+class TestFormatDescribeErrors:
+    def test_invalid_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid"):
+            format_describe("widget", {}, output_format="table")


### PR DESCRIPTION
## Summary

Reworks `content list` and adds `content describe` so that both humans and AI agents can quickly find and understand XSOAR content (commands, scripts, playbooks) without saving temporary files or grepping large JSON dumps.

Previously `content list` always emitted one large JSON blob (the sample we worked from was ~6,250 lines). The output is now a curated, scannable summary by default, with a search filter for discovery and a separate detail command for per-item inspection.

## Changes

### `content list`
- **`--output-format [table|json|plain]`** (default: `table`). Table is human-readable aligned columns, `json` is machine-readable, `plain` is tab-separated values for piping to `grep`/`cut`/`awk`.
- **`--search TERM`** — case-insensitive substring filter on each item's id, name, and description. For commands, only matching commands within a brand are kept; brands and content types with no matches are omitted. A clear `No content matching '<term>' found.` message is shown when nothing matches.
- Consistent columns across types: scripts and playbooks both show ID + Description (playbook description read from the `comment` field); commands show command name + description, with the integration brand dropped (it is not needed to invoke a command).
- **Removed `--detail-level`** (and its `short`/`extended`/`full` levels). `content list` now always produces the curated summary; per-item detail moved to `content describe`.

### `content describe` (new)
- `content describe --type [script|playbook|command] NAME` shows a single item in detail: description, arguments, and inputs/outputs.
- Commands additionally show a standalone `Brand:` line and an `Instances:` section listing each configured instance's name and state (verified against a multi-instance ServiceNow setup).
- Lookup is case-insensitive: scripts match on id, playbooks on id or name (so UUID-id custom playbooks resolve by their human name), commands on command name.
- `--output-format [table|json]` (default: `table`). Not found exits non-zero with a clear error.

## Breaking changes
- `content list` default output is now a table instead of JSON. Use `--output-format json` for machine-readable output.
- `content list --detail-level` is removed.
- The summary-level JSON structure for commands is now a list of `{name, description}` objects instead of plain command-name strings.

## Testing
- Implemented test-first (TDD) for `--search`, the describe data layer, the describe output formatter, and the describe command.
- Full suite passes (545 tests); lint and format clean.
- Verified end-to-end against the live dev instance: all three list types, search, all output formats, and describe for script/playbook/command including the multi-instance command, not-found, and invalid-argument cases.

Docs (`CHANGELOG.md` and the content command `README.md`) are updated.
